### PR TITLE
docs: update OpenSSF Scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![codecov](https://codecov.io/gh/DarkRockMountain/gomail/graph/badge.svg?token=NC0O7RMK2X)](https://codecov.io/gh/DarkRockMountain/gomail)
 ![Vulnerability assessment Status](https://github.com/darkrockmountain/gomail/actions/workflows/govulncheck.yaml/badge.svg)
 [![FOSSA Status](https://app.fossa.com/api/projects/custom%2B45301%2Fgithub.com%2FDarkRockMountain%2Fgomail.svg?type=shield&issueType=license)](https://app.fossa.com/projects/custom%2B45301%2Fgithub.com%2FDarkRockMountain%2Fgomail?ref=badge_shield&issueType=license)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/darkrockmountain/gomail/badge)](https://scorecard.dev/viewer/?uri=github.com/darkrockmountain/gomail)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/DarkRockMountain/gomail/badge)](https://scorecard.dev/viewer/?uri=github.com/DarkRockMountain/gomail)
 [![GitHub Release](https://img.shields.io/github/v/release/darkrockmountain/gomail)](https://github.com/darkrockmountain/gomail/releases)
 <!-- [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=your-project-key&metric=alert_status)](https://sonarcloud.io/dashboard?id=your-project-key) -->
 ## Project Description


### PR DESCRIPTION
## Fixed README's OpenSSF Scorecard

fix: update OpenSSF Scorecard URL and badge in README.md

### Description

This pull request fixes the incorrect URL and badge logo in the `README.md` file for the OpenSSF Scorecard report.

- **Related Issue**: Closes #1 
- **Type of Change**:
  - Bug fix (non-breaking change which fixes an issue)

### Checklist

Please ensure the following guidelines are met:

- [x] The code follows the style guidelines of this project.
- [x] A self-review has been performed on the code.
- [x] The code is well-documented, and comments have been added where necessary.
- [ ] Tests have been added to prove that the fix is effective or that the feature works. All existing tests pass.
- [x] Commit messages follow the convention `type(scope): description`.
- [x] The pull request has no conflicts with the base branch.
- [ ] Any dependent changes have been merged and published in downstream modules.

### Additional Information

This pull request updates the badge URL to:

[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/DarkRockMountain/gomail/badge)](https://scorecard.dev/viewer/?uri=github.com/DarkRockMountain/gomail)

