### PR TITLE
refactor(providers): separate all email providers into individual packages

### DIFF
--- a/.examples/.serverless/aws_lambda/lambda_email_sender.go
+++ b/.examples/.serverless/aws_lambda/lambda_email_sender.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/darkrockmountain/gomail"
-	"github.com/darkrockmountain/gomail/providers"
+	"github.com/darkrockmountain/gomail/providers/smtp"
 )
 
 // handler is the main Lambda function handler that processes the incoming API Gateway request
@@ -38,11 +38,11 @@ func handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyRespo
 	}
 	user := os.Getenv("SMTP_USER")
 	password := os.Getenv("SMTP_PASSWORD")
-	authMethod := providers.AuthMethod(os.Getenv("SMTP_AUTH_METHOD"))
+	authMethod := smtp.AuthMethod(os.Getenv("SMTP_AUTH_METHOD"))
 
 	// Initialize the SMTP email sender with the retrieved configuration values.
 	// You can choose any other email sender implementation by replacing NewSmtpEmailSender with another constructor.
-	sender, err := providers.NewSmtpEmailSender(
+	sender, err := smtp.NewSmtpEmailSender(
 		host,
 		port,
 		user,

--- a/.examples/.serverless/azure_functions/azure_email_sender.go
+++ b/.examples/.serverless/azure_functions/azure_email_sender.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 
 	"github.com/darkrockmountain/gomail"
-	"github.com/darkrockmountain/gomail/providers"
+	"github.com/darkrockmountain/gomail/providers/smtp"
 )
 
 // SendEmail is the HTTP handler that processes the incoming request
@@ -31,11 +31,11 @@ func SendEmail(w http.ResponseWriter, r *http.Request) {
 	}
 	user := os.Getenv("SMTP_USER")
 	password := os.Getenv("SMTP_PASSWORD")
-	authMethod := providers.AuthMethod(os.Getenv("SMTP_AUTH_METHOD"))
+	authMethod := smtp.AuthMethod(os.Getenv("SMTP_AUTH_METHOD"))
 
 	// Initialize the SMTP email sender with the retrieved configuration values.
 	// You can choose any other email sender implementation by replacing NewSmtpEmailSender with another constructor.
-	sender, err := providers.NewSmtpEmailSender(
+	sender, err := smtp.NewSmtpEmailSender(
 		host,
 		port,
 		user,

--- a/.examples/.serverless/digitalocean_functions/packages/email-sender/send-post/main.go
+++ b/.examples/.serverless/digitalocean_functions/packages/email-sender/send-post/main.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 
 	"github.com/darkrockmountain/gomail"
-	"github.com/darkrockmountain/gomail/providers"
+	"github.com/darkrockmountain/gomail/providers/smtp"
 )
 
 type ResponseHeaders struct {
@@ -39,9 +39,9 @@ func Main(ctx context.Context, emailReq gomail.EmailMessage) Response {
 	}
 	user := os.Getenv("SMTP_USER")
 	password := os.Getenv("SMTP_PASSWORD")
-	authMethod := providers.AuthMethod(os.Getenv("SMTP_AUTH_METHOD"))
+	authMethod := smtp.AuthMethod(os.Getenv("SMTP_AUTH_METHOD"))
 
-	sender, err := providers.NewSmtpEmailSender(host, port, user, password, authMethod)
+	sender, err := smtp.NewSmtpEmailSender(host, port, user, password, authMethod)
 	if err != nil {
 		return generateResponse(http.StatusInternalServerError, "Failed to initialize email sender")
 

--- a/.examples/.serverless/google_cloud_functions/gcf_email_sender.go
+++ b/.examples/.serverless/google_cloud_functions/gcf_email_sender.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
 	"github.com/darkrockmountain/gomail"
-	"github.com/darkrockmountain/gomail/providers"
+	"github.com/darkrockmountain/gomail/providers/smtp"
 )
 
 func SendEmail(w http.ResponseWriter, r *http.Request) {
@@ -30,9 +30,9 @@ func SendEmail(w http.ResponseWriter, r *http.Request) {
 	}
 	user := os.Getenv("SMTP_USER")
 	password := os.Getenv("SMTP_PASSWORD")
-	authMethod := providers.AuthMethod(os.Getenv("SMTP_AUTH_METHOD"))
+	authMethod := smtp.AuthMethod(os.Getenv("SMTP_AUTH_METHOD"))
 
-	sender, err = providers.NewSmtpEmailSender(
+	sender, err = smtp.NewSmtpEmailSender(
 		host,
 		port,
 		user,

--- a/README.md
+++ b/README.md
@@ -46,52 +46,52 @@ go mod tidy
 ### Usage
 
 #### 1. SMTP Email Sender
-- Configure your SMTP server settings in `providers/smtp_email_sender.go`.
+- Configure your SMTP server settings in `providers/smpt/smtp_email_sender.go`.
 - Refer to the [SMTP Credentials Documentation](./docs/SMTP_Credentials.md) for details on obtaining credentials.
 - Run the `smtpExample()` function to send a test email.
 
 #### 2. Gmail Email Sender
-- Configure your Gmail API credentials in `providers/gmail_email_sender.go`.
+- Configure your Gmail API credentials in `providers/gmail/gmail_email_sender.go`.
 - Refer to the [Gmail Credentials Documentation](./docs/Gmail_Credentials_API_Key.md) for details on obtaining credentials.
 - Run the `gExample()` function to send a test email.
 
 #### 3. Gmail Email Sender using OAuth2
-- Configure your Gmail API credentials and token in `providers/gmail_email_sender_oauth2.go`.
+- Configure your Gmail API credentials and token in `providers/gmail/gmail_email_sender_oauth2.go`.
 - Refer to the [Gmail OAuth2 Credentials Documentation](./docs/Gmail_Credentials_OAuth2.md) for details on obtaining credentials.
 - Run the `gExampleOauth2()` function to send a test email.
 
 #### 4. Microsoft 365 Email Sender
-- Configure your Microsoft Graph API credentials in `providers/microsoft365_email_sender.go`.
+- Configure your Microsoft Graph API credentials in `providers/microsoft365/microsoft365_email_sender.go`.
 - Refer to the [Microsoft 365 Credentials Documentation](./docs/Microsoft365_Credentials_ROPC.md) for details on obtaining credentials.
 - Run the `msGraphExample()` function to send a test email.
 
 #### 5. SendGrid Email Sender
-- Configure your SendGrid API key in `providers/sendgrid_email_sender.go`.
+- Configure your SendGrid API key in `providers/sendgrid/sendgrid_email_sender.go`.
 - Refer to the [SendGrid Credentials Documentation](./docs/SendGrid_Credentials.md) for details on obtaining credentials.
 - Run the `sendgridExample()` function to send a test email.
 
 #### 6. AWS SES Email Sender
-- Configure your AWS SES credentials in `providers/ses_email_sender.go`.
+- Configure your AWS SES credentials in `providers/ses/ses_email_sender.go`.
 - Refer to the [AWS SES Credentials Documentation](./docs/AWS_SES_Credentials.md) for details on obtaining credentials.
 - Run the `sesExample()` function to send a test email.
 
 #### 7. Mailgun Email Sender
-- Configure your Mailgun API key in `providers/mailgun_email_sender.go`.
+- Configure your Mailgun API key in `providers/mailgun/mailgun_email_sender.go`.
 - Refer to the [Mailgun Credentials Documentation](./docs/Mailgun_Credentials.md) for details on obtaining credentials.
 - Run the `mailgunExample()` function to send a test email.
 
 #### 8. Mandrill Email Sender
-- Configure your Mandrill API key in `providers/mandrill_email_sender.go`.
+- Configure your Mandrill API key in `providers/mandrill/mandrill_email_sender.go`.
 - Refer to the [Mandrill Credentials Documentation](./docs/Mandrill_Credentials.md) for details on obtaining credentials.
 - Run the `mandrillExample()` function to send a test email.
 
 #### 9. Postmark Email Sender
-- Configure your Postmark API key in `providers/postmark_email_sender.go`.
+- Configure your Postmark API key in `providers/postmark/postmark_email_sender.go`.
 - Refer to the [Postmark Credentials Documentation](./docs/Postmark_Credentials.md) for details on obtaining credentials.
 - Run the `postmarkExample()` function to send a test email.
 
 #### 10. SparkPost Email Sender
-- Configure your SparkPost API key in `providers/sparkpost_email_sender.go`.
+- Configure your SparkPost API key in `providers/sparkpost/sparkpost_email_sender.go`.
 - Refer to the [SparkPost Documentation](https://developers.sparkpost.com/api/) for details on obtaining credentials.
 - Run the `sparkpostExample()` function to send a test email.
 

--- a/docs/Gmail_Credentials_API_Key.md
+++ b/docs/Gmail_Credentials_API_Key.md
@@ -31,7 +31,7 @@ apiKey := "your-api-key"
 user := "me"
 
 // Initialize the GmailEmailSender
-emailSender, err := providers.NewGmailEmailSenderAPIKey(apiKey, user)
+emailSender, err := gmail.NewGmailEmailSenderAPIKey(apiKey, user)
 if err != nil {
     log.Fatalf("Failed to create GmailEmailSender: %v", err)
 }

--- a/docs/Gmail_Credentials_JWT.md
+++ b/docs/Gmail_Credentials_JWT.md
@@ -71,7 +71,7 @@ jsonCredentials := []byte(`{
 user := "user@domain.com"
 
 // Initialize the GmailEmailSender
-emailSender, err := providers.NewGmailEmailSenderJWT(jsonCredentials, user)
+emailSender, err := gmail.NewGmailEmailSenderJWT(jsonCredentials, user)
 if err != nil {
     log.Fatalf("Failed to create GmailEmailSender: %v", err)
 }

--- a/docs/Gmail_Credentials_OAuth2.md
+++ b/docs/Gmail_Credentials_OAuth2.md
@@ -17,7 +17,7 @@ jsonCredentials := []byte(`{
 user := "user@domain.com"
 
 // Initialize the GmailEmailSender
-emailSender, err := providers.NewGmailEmailSenderServiceAccount(jsonCredentials, user)
+emailSender, err := gmail.NewGmailEmailSenderServiceAccount(jsonCredentials, user)
 if err != nil {
     log.Fatalf("Failed to create GmailEmailSender: %v", err)
 }
@@ -131,7 +131,7 @@ tokenManager := &MyTokenManager{
 }
 
 // Create GmailEmailSender with the parsed credentials and token
-emailSender, err := providers.NewGmailEmailSenderOauth2(credentials, tokenManager, "me")
+emailSender, err := gmail.NewGmailEmailSenderOauth2(credentials, tokenManager, "me")
 if err != nil {
 	log.Fatalf("Failed to create email sender: %v", err)
 }

--- a/docs/Gmail_Credentials_ServiceAccount copy.md
+++ b/docs/Gmail_Credentials_ServiceAccount copy.md
@@ -72,7 +72,7 @@ jsonCredentials := []byte(`{
 user := "user@domain.com"
 
 // Initialize the GmailEmailSender
-emailSender, err := providers.NewGmailEmailSenderJWTAccess(jsonCredentials, user)
+emailSender, err := gmail.NewGmailEmailSenderJWTAccess(jsonCredentials, user)
 if err != nil {
     log.Fatalf("Failed to create GmailEmailSender: %v", err)
 }

--- a/docs/Gmail_Credentials_ServiceAccount.md
+++ b/docs/Gmail_Credentials_ServiceAccount.md
@@ -65,7 +65,7 @@ jsonCredentials := []byte(`{
 user := "user@domain.com"
 
 // Initialize the GmailEmailSender
-emailSender, err := providers.NewGmailEmailSenderServiceAccount(jsonCredentials, user)
+emailSender, err := gmail.NewGmailEmailSenderServiceAccount(jsonCredentials, user)
 if err != nil {
     log.Fatalf("Failed to create GmailEmailSender: %v", err)
 }

--- a/docs/SMTP_Credentials.md
+++ b/docs/SMTP_Credentials.md
@@ -29,7 +29,7 @@ password := "your-password"
 authMethod := AUTH_PLAIN
 
 // Create SmtpEmailSender with the SMTP server settings
-emailSender, _ := providers.NewSmtpEmailSender(
+emailSender, _ := gmail.NewSmtpEmailSender(
     host,
     port,
     user,

--- a/email_sender.go
+++ b/email_sender.go
@@ -9,6 +9,7 @@
 // This project is organized into several packages:
 //
 // - providers: Contains implementations for various email providers.
+// - credentials: Contains implementations for managing email credentials.
 // - examples: Contains example applications demonstrating how to use the library.
 // - docs: Contains documentation for configuring different email providers.
 //
@@ -22,12 +23,12 @@
 //	package main
 //
 //	import (
-//	    "github.com/darkrockmountain/gomail/providers"
+//	    "github.com/darkrockmountain/gomail/providers/sendgrid"
 //	)
 //
 //	func main() {
-//	    sender := providers.NewSendGridEmailSender("your-api-key")
-//	    err := sender.SendEmail("recipient@example.com", "Subject", "Email body")
+//	    sender := sendgrid.NewSendGridEmailSender("your-api-key")
+//	    err := sender.SendEmail(EmailMessage{To:[]string{"recipient@example.com"}, Subject:"Subject", Text:"Email body"})
 //	    if err != nil {
 //	        log.Fatal(err)
 //	    }

--- a/providers/doc.go
+++ b/providers/doc.go
@@ -17,11 +17,12 @@
 //
 //	import (
 //	    "github.com/darkrockmountain/gomail"
+//	    "github.com/darkrockmountain/gomail/providers/sendgrid"
 //	)
 //
 //	func main() {
-//	    sender := providers.NewSendGridEmailSender("your-api-key")
-//	    err := sender.SendEmail("recipient@example.com", "Subject", "Email body")
+//	    sender := sendgrid.NewSendGridEmailSender("your-api-key")
+//	    err := sender.SendEmail(EmailMessage{To:[]string{"recipient@example.com"}, Subject:"Subject", Text:"Email body"})
 //	    if err != nil {
 //	        log.Fatal(err)
 //	    }

--- a/providers/gmail/gmail_email_sender.go
+++ b/providers/gmail/gmail_email_sender.go
@@ -1,4 +1,4 @@
-package providers
+package gmail
 
 import (
 	"bytes"
@@ -10,6 +10,7 @@ import (
 
 	"github.com/darkrockmountain/gomail"
 	"github.com/darkrockmountain/gomail/credentials"
+	"github.com/darkrockmountain/gomail/providers"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
@@ -47,7 +48,7 @@ func (ms *gmailMessageSenderWrapper) send(message *gmail.Message) (*gmail.Messag
 // Returns:
 //   - error: An error if sending the email fails.
 func (s *gmailMessageSenderWrapper) SendEmail(message gomail.EmailMessage) error {
-	mimeMessage, err := buildMimeMessage(message)
+	mimeMessage, err := providers.BuildMimeMessage(message)
 	if err != nil {
 		return fmt.Errorf("unable to build MIME message: %w", err)
 	}

--- a/providers/gmail/gmail_email_sender_test.go
+++ b/providers/gmail/gmail_email_sender_test.go
@@ -1,4 +1,4 @@
-package providers
+package gmail
 
 import (
 	"bytes"

--- a/providers/helper_functions.go
+++ b/providers/helper_functions.go
@@ -9,7 +9,7 @@ import (
 	"github.com/darkrockmountain/gomail"
 )
 
-// buildMimeMessage constructs the MIME message for the email, including text, HTML, and attachments.
+// BuildMimeMessage constructs the MIME message for the email, including text, HTML, and attachments.
 // This function builds a multipart MIME message based on the provided email message. It supports plain text,
 // HTML content, and multiple attachments.
 //
@@ -35,12 +35,12 @@ import (
 //	        },
 //	    },
 //	}
-//	mimeMessage, err := buildMimeMessage(message)
+//	mimeMessage, err := BuildMimeMessage(message)
 //	if err != nil {
 //	    log.Fatalf("Failed to build MIME message: %v", err)
 //	}
 //	fmt.Println(string(mimeMessage))
-func buildMimeMessage(message gomail.EmailMessage) ([]byte, error) {
+func BuildMimeMessage(message gomail.EmailMessage) ([]byte, error) {
 	var msg bytes.Buffer
 
 	// Determine boundaries
@@ -127,7 +127,7 @@ func buildMimeMessage(message gomail.EmailMessage) ([]byte, error) {
 	return msg.Bytes(), nil
 }
 
-// strPtr takes a string value and returns a pointer to that string.
+// StrPtr takes a string value and returns a pointer to that string.
 // This function is useful when you need to work with string pointers, such as in
 // scenarios where you need to pass a string by reference or handle optional string fields.
 //
@@ -140,12 +140,12 @@ func buildMimeMessage(message gomail.EmailMessage) ([]byte, error) {
 // Example usage:
 //
 //	name := "John Doe"
-//	namePtr := strPtr(name)
+//	namePtr := StrPtr(name)
 //	fmt.Println(namePtr)  // Output: memory address of the string
 //	fmt.Println(*namePtr) // Output: "John Doe"
 //
 // Detailed explanation:
-// The strPtr function creates a pointer to the given string `str`.
+// The StrPtr function creates a pointer to the given string `str`.
 // This can be particularly useful in the following scenarios:
 //  1. Passing strings by reference to functions, which can help avoid copying large strings.
 //  2. Working with data structures that use pointers to represent optional fields or nullable strings.
@@ -153,6 +153,6 @@ func buildMimeMessage(message gomail.EmailMessage) ([]byte, error) {
 //
 // By using this function, you can easily obtain a pointer to a string and utilize it in contexts
 // where pointers are needed, thus enhancing flexibility and efficiency in your Go programs.
-func strPtr(str string) *string {
+func StrPtr(str string) *string {
 	return &str
 }

--- a/providers/helper_functions_test.go
+++ b/providers/helper_functions_test.go
@@ -49,7 +49,7 @@ func TestBuildMimeMessage(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.message.Subject, func(t *testing.T) {
-			result, err := buildMimeMessage(test.message)
+			result, err := BuildMimeMessage(test.message)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/providers/mailgun/mailgun_email_sender.go
+++ b/providers/mailgun/mailgun_email_sender.go
@@ -1,4 +1,4 @@
-package providers
+package mailgun
 
 import (
 	"context"

--- a/providers/mailgun/mailgun_email_sender_test.go
+++ b/providers/mailgun/mailgun_email_sender_test.go
@@ -1,4 +1,4 @@
-package providers
+package mailgun
 
 import (
 	"context"

--- a/providers/mandrill/mandrill_email_sender.go
+++ b/providers/mandrill/mandrill_email_sender.go
@@ -1,5 +1,5 @@
 // mandrill_email_sender.go
-package providers
+package mandrill
 
 import (
 	"bytes"

--- a/providers/mandrill/mandrill_email_sender_test.go
+++ b/providers/mandrill/mandrill_email_sender_test.go
@@ -1,4 +1,4 @@
-package providers
+package mandrill
 
 import (
 	"net/http"
@@ -9,19 +9,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewPostmarkEmailSender(t *testing.T) {
-	serverToken := "test-server-token"
-	emailSender, err := NewPostmarkEmailSender(serverToken)
+func TestNewMandrillEmailSender(t *testing.T) {
+	apiKey := "test-api-key"
+	emailSender, err := NewMandrillEmailSender(apiKey)
 	assert.NoError(t, err)
 	assert.NotNil(t, emailSender)
-	assert.Equal(t, serverToken, emailSender.serverToken)
-	assert.Equal(t, postMarkRequestMethod, emailSender.requestMethod)
-	assert.Equal(t, postMarkRequestURL, emailSender.url)
+	assert.Equal(t, apiKey, emailSender.apiKey)
 }
 
-func TestPostmarkEmailSender_SendEmail(t *testing.T) {
-	emailSender, err := NewPostmarkEmailSender("test-server-token")
+func TestMandrillEmailSender_SendEmail(t *testing.T) {
+	emailSender, err := NewMandrillEmailSender("test-api-key")
 	assert.NoError(t, err)
+
 	message := gomail.EmailMessage{
 		From:    "sender@example.com",
 		To:      []string{"recipient@example.com"},
@@ -52,11 +51,12 @@ func TestPostmarkEmailSender_SendEmail(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestPostmarkEmailSender_SendEmailWithMarshalError(t *testing.T) {
-	emailSender, err := NewPostmarkEmailSender("test-server-token")
+func TestMandrillEmailSender_SendEmailWithError(t *testing.T) {
+	emailSender, err := NewMandrillEmailSender("test-api-key")
 	assert.NoError(t, err)
+
 	message := gomail.EmailMessage{
-		From:    string(make([]byte, 1<<20)), // Intentionally large string to cause marshal error
+		From:    string(make([]byte, 1<<20)), // Intentionally large string to cause error
 		To:      []string{"recipient@example.com"},
 		Subject: "Test Email",
 		Text:    "This is a test email.",
@@ -66,25 +66,8 @@ func TestPostmarkEmailSender_SendEmailWithMarshalError(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestPostmarkEmailSender_SendEmailWithRequestCreationError(t *testing.T) {
-	emailSender, err := NewPostmarkEmailSender("test-server-token")
-	assert.NoError(t, err)
-
-	message := gomail.EmailMessage{
-		From:    "sender@example.com",
-		To:      []string{"recipient@example.com"},
-		Subject: "Test Email",
-		Text:    "This is a test email.",
-	}
-
-	// Mock the JSON marshal function to cause an error
-
-	err = emailSender.SendEmail(message)
-	assert.Error(t, err)
-}
-
-func TestPostmarkEmailSender_SendEmailWithSendError(t *testing.T) {
-	emailSender, err := NewPostmarkEmailSender("test-server-token")
+func TestMandrillEmailSender_SendEmailWithSendError(t *testing.T) {
+	emailSender, err := NewMandrillEmailSender("test-api-key")
 	assert.NoError(t, err)
 
 	message := gomail.EmailMessage{
@@ -104,11 +87,11 @@ func TestPostmarkEmailSender_SendEmailWithSendError(t *testing.T) {
 
 	err = emailSender.SendEmail(message)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to send email via Postmark API")
+	assert.Contains(t, err.Error(), "failed to send email via Mandrill API")
 }
 
-func TestPostmarkEmailSender_SendEmailWithNon200StatusCode(t *testing.T) {
-	emailSender, err := NewPostmarkEmailSender("test-server-token")
+func TestMandrillEmailSender_SendEmailWithNon200StatusCode(t *testing.T) {
+	emailSender, err := NewMandrillEmailSender("test-api-key")
 	assert.NoError(t, err)
 
 	message := gomail.EmailMessage{
@@ -131,8 +114,8 @@ func TestPostmarkEmailSender_SendEmailWithNon200StatusCode(t *testing.T) {
 	assert.Contains(t, err.Error(), "status code: 400")
 }
 
-func TestPostmarkEmailSender_SendEmailWithEmptyFields(t *testing.T) {
-	emailSender, err := NewPostmarkEmailSender("test-server-token")
+func TestMandrillEmailSender_SendEmailWithEmptyFields(t *testing.T) {
+	emailSender, err := NewMandrillEmailSender("test-api-key")
 	assert.NoError(t, err)
 
 	message := gomail.EmailMessage{

--- a/providers/microsoft365/microsoft365_email_sender.go
+++ b/providers/microsoft365/microsoft365_email_sender.go
@@ -1,4 +1,4 @@
-package providers
+package microsoft365
 
 import (
 	"context"
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/darkrockmountain/gomail"
+	"github.com/darkrockmountain/gomail/providers"
 	azureAuth "github.com/microsoft/kiota-authentication-azure-go"
 	msgraph "github.com/microsoftgraph/msgraph-sdk-go"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
@@ -59,15 +60,14 @@ func composeMsMessage(message gomail.EmailMessage) *models.Message {
 	if message.GetHTML() != "" {
 		htmlBodyType := models.HTML_BODYTYPE
 		body.SetContentType(&htmlBodyType)
-		body.SetContent(strPtr(message.GetHTML()))
+		body.SetContent(providers.StrPtr(message.GetHTML()))
 	} else {
 		textBodyType := models.TEXT_BODYTYPE
 		body.SetContentType(&textBodyType)
-		body.SetContent(strPtr(message.GetText()))
+		body.SetContent(providers.StrPtr(message.GetText()))
 	}
-
 	msMessage := models.NewMessage()
-	msMessage.SetSubject(strPtr(message.GetSubject()))
+	msMessage.SetSubject(providers.StrPtr(message.GetSubject()))
 	msMessage.SetBody(body)
 
 	// Add sender
@@ -138,7 +138,7 @@ func composeMsMessage(message gomail.EmailMessage) *models.Message {
 		msAttachments := make([]models.Attachmentable, len(attachments))
 		for i, attachment := range attachments {
 			fileAttachment := models.NewFileAttachment()
-			fileAttachment.SetName(strPtr(attachment.GetFilename()))
+			fileAttachment.SetName(providers.StrPtr(attachment.GetFilename()))
 			fileAttachment.SetContentBytes([]byte(attachment.GetBase64StringContent()))
 			msAttachments[i] = fileAttachment
 		}

--- a/providers/microsoft365/microsoft365_email_sender_test.go
+++ b/providers/microsoft365/microsoft365_email_sender_test.go
@@ -1,4 +1,4 @@
-package providers
+package microsoft365
 
 import (
 	"bytes"

--- a/providers/postmark/postmark_email_sender.go
+++ b/providers/postmark/postmark_email_sender.go
@@ -1,4 +1,4 @@
-package providers
+package postmark
 
 import (
 	"bytes"

--- a/providers/sendgrid/sendgrid_email_sender.go
+++ b/providers/sendgrid/sendgrid_email_sender.go
@@ -1,4 +1,4 @@
-package providers
+package sendgrid
 
 import (
 	"fmt"

--- a/providers/sendgrid/sendgrid_email_sender_test.go
+++ b/providers/sendgrid/sendgrid_email_sender_test.go
@@ -1,4 +1,4 @@
-package providers
+package sendgrid
 
 import (
 	"encoding/base64"

--- a/providers/ses/ses_email_sender.go
+++ b/providers/ses/ses_email_sender.go
@@ -1,4 +1,4 @@
-package providers
+package ses
 
 import (
 	"fmt"

--- a/providers/ses/ses_email_sender_test.go
+++ b/providers/ses/ses_email_sender_test.go
@@ -1,4 +1,4 @@
-package providers
+package ses
 
 import (
 	"errors"

--- a/providers/smtp/smtp_email_sender.go
+++ b/providers/smtp/smtp_email_sender.go
@@ -1,4 +1,4 @@
-package providers
+package smtp
 
 import (
 	"crypto/tls"
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/darkrockmountain/gomail"
+	"github.com/darkrockmountain/gomail/providers"
 )
 
 // smtpEmailSender is responsible for sending emails using SMTP.
@@ -86,8 +87,7 @@ func (s *smtpEmailSender) SendEmail(message gomail.EmailMessage) error {
 	sendMailTo := message.GetTo()
 	sendMailTo = append(sendMailTo, message.GetCC()...)
 	sendMailTo = append(sendMailTo, message.GetBCC()...)
-
-	msg, err := buildMimeMessage(message)
+	msg, err := providers.BuildMimeMessage(message)
 	if err != nil {
 		return err
 	}

--- a/providers/smtp/smtp_email_sender_test.go
+++ b/providers/smtp/smtp_email_sender_test.go
@@ -1,4 +1,4 @@
-package providers
+package smtp
 
 import (
 	"crypto/tls"

--- a/providers/sparkpost/sparkpost_email_sender.go
+++ b/providers/sparkpost/sparkpost_email_sender.go
@@ -1,4 +1,4 @@
-package providers
+package sparkpost
 
 import (
 	"fmt"

--- a/providers/sparkpost/sparkpost_email_sender_test.go
+++ b/providers/sparkpost/sparkpost_email_sender_test.go
@@ -1,4 +1,4 @@
-package providers
+package sparkpost
 
 import (
 	"crypto/tls"


### PR DESCRIPTION
## Feature/refactor providers package

refactor(providers): separate all email providers into individual packages

### Description

This pull request refactors the `providers` package by separating each email provider implementation into its own package. This change improves modularity and maintains a clean code structure, making it easier to manage and extend the codebase.

- **Related Issue**: Closes #4 
- **Type of Change**:
  - New feature (non-breaking change which adds functionality)
  - This change requires a documentation update

### Checklist

Please ensure the following guidelines are met:

- [x] The code follows the style guidelines of this project.
- [x] A self-review has been performed on the code.
- [x] The code is well-documented, and comments have been added where necessary.
- [x] Tests have been added to prove that the fix is effective or that the feature works. All existing tests pass.
- [x] Commit messages follow the convention `type(scope): description`.
- [x] The pull request has no conflicts with the base branch.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional Information

The following changes were made:
- Created individual packages for each email provider (e.g., `smtp`, `gmail`, `sendgrid`, etc.).
- Updated import paths in the codebase to reflect the new package structure.
- Updated documentation to match the new package structure.