### PR TITLE
feat(EmailMessage): change EmailMessage parameter to pointer in EmailSender interface for efficiency.

### DIFF
--- a/docs/AWS_SES_Credentials.md
+++ b/docs/AWS_SES_Credentials.md
@@ -44,7 +44,7 @@ if err != nil {
 }
 
 // Define email message
-message := *gomail.NewEmailMessage(sender,[]string{"recipient@example.com"}, "Test Email with attachment", "This is the plain text part of the email.").
+message := gomail.NewEmailMessage(sender,[]string{"recipient@example.com"}, "Test Email with attachment", "This is the plain text part of the email.").
 		SetHTML("<p>This is the <b>HTML</b> part of the <i>email</i>.</p>").
 		AddAttachments(gomail.Attachment{
 			Filename: "attachment.jpg",  Content: attachmentContent,

--- a/docs/Gmail_Credentials_API_Key.md
+++ b/docs/Gmail_Credentials_API_Key.md
@@ -43,7 +43,7 @@ if err != nil {
 }
 
 // Define email message using an alias email address
-message := *gomail.NewEmailMessage("your-email_or_alias@example.com",[]string{"recipient@example.com"}, "Test Email with attachment", "This is the plain text part of the email.").
+message := gomail.NewEmailMessage("your-email_or_alias@example.com",[]string{"recipient@example.com"}, "Test Email with attachment", "This is the plain text part of the email.").
 		SetHTML("<p>This is the <b>HTML</b> part of the <i>email</i>.</p>").AddAttachments(gomail.Attachment{
 			Filename: "attachment.jpg",  Content: attachmentContent,
 		})

--- a/docs/Gmail_Credentials_JWT.md
+++ b/docs/Gmail_Credentials_JWT.md
@@ -83,7 +83,7 @@ if err != nil {
 }
 
 // Define email message using an alias email address
-message := *gomail.NewEmailMessage("your-email_or_alias@example.com",[]string{"recipient@example.com"}, "Test Email with attachment", "This is the plain text part of the email.").
+message := gomail.NewEmailMessage("your-email_or_alias@example.com",[]string{"recipient@example.com"}, "Test Email with attachment", "This is the plain text part of the email.").
 		SetHTML("<p>This is the <b>HTML</b> part of the <i>email</i>.</p>").AddAttachments(gomail.Attachment{
 			Filename: "attachment.jpg",  Content: attachmentContent,
 		})

--- a/docs/Gmail_Credentials_OAuth2.md
+++ b/docs/Gmail_Credentials_OAuth2.md
@@ -143,7 +143,7 @@ if err != nil {
 }
 
 // Define email message using an alias email address
-message := *gomail.NewEmailMessage("your-email_or_alias@example.com",[]string{"recipient@example.com"}, "Test Email with attachment", "This is the plain text part of the email.").
+message := gomail.NewEmailMessage("your-email_or_alias@example.com",[]string{"recipient@example.com"}, "Test Email with attachment", "This is the plain text part of the email.").
 		SetHTML("<p>This is the <b>HTML</b> part of the <i>email</i>.</p>").AddAttachments(gomail.Attachment{
 			Filename: "attachment.jpg",  Content: attachmentContent,
 		})

--- a/docs/Gmail_Credentials_ServiceAccount copy.md
+++ b/docs/Gmail_Credentials_ServiceAccount copy.md
@@ -84,7 +84,7 @@ if err != nil {
 }
 
 // Define email message using an alias email address
-message := *gomail.NewEmailMessage("your-email_or_alias@example.com",[]string{"recipient@example.com"}, "Test Email with attachment", "This is the plain text part of the email.").
+message := gomail.NewEmailMessage("your-email_or_alias@example.com",[]string{"recipient@example.com"}, "Test Email with attachment", "This is the plain text part of the email.").
 		SetHTML("<p>This is the <b>HTML</b> part of the <i>email</i>.</p>").AddAttachments(gomail.Attachment{
 			Filename: "attachment.jpg",  Content: attachmentContent,
 		})

--- a/docs/Gmail_Credentials_ServiceAccount.md
+++ b/docs/Gmail_Credentials_ServiceAccount.md
@@ -77,7 +77,7 @@ if err != nil {
 }
 
 // Define email message using an alias email address
-message := *gomail.NewEmailMessage("your-email_or_alias@example.com",[]string{"recipient@example.com"}, "Test Email with attachment", "This is the plain text part of the email.").
+message := gomail.NewEmailMessage("your-email_or_alias@example.com",[]string{"recipient@example.com"}, "Test Email with attachment", "This is the plain text part of the email.").
 		SetHTML("<p>This is the <b>HTML</b> part of the <i>email</i>.</p>").AddAttachments(gomail.Attachment{
 			Filename: "attachment.jpg",  Content: attachmentContent,
 		})

--- a/docs/Mailgun_Credentials.md
+++ b/docs/Mailgun_Credentials.md
@@ -41,7 +41,7 @@ if err != nil {
 }
 
 // Define email message
-message := *gomail.NewEmailMessage("your-email_or_alias@example.com",[]string{"recipient@example.com"}, "Test Email with attachment", "This is the plain text part of the email.").
+message := gomail.NewEmailMessage("your-email_or_alias@example.com",[]string{"recipient@example.com"}, "Test Email with attachment", "This is the plain text part of the email.").
 		SetHTML("<p>This is the <b>HTML</b> part of the <i>email</i>.</p>").AddAttachments(gomail.Attachment{
 			Filename: "attachment.jpg",  Content: attachmentContent,
 		})

--- a/docs/Mandrill_Credentials.md
+++ b/docs/Mandrill_Credentials.md
@@ -37,7 +37,7 @@ if err != nil {
 }
 
 // Define email message
-message := *gomail.NewEmailMessage("your-email_or_alias@example.com",[]string{"recipient@example.com"}, "Test Email with attachment", "This is the plain text part of the email.").
+message := gomail.NewEmailMessage("your-email_or_alias@example.com",[]string{"recipient@example.com"}, "Test Email with attachment", "This is the plain text part of the email.").
 		SetHTML("<p>This is the <b>HTML</b> part of the <i>email</i>.</p>").AddAttachments(gomail.Attachment{
 			Filename: "attachment.jpg",  Content: attachmentContent,
 		})

--- a/docs/Microsoft365_Credentials_ROPC.md
+++ b/docs/Microsoft365_Credentials_ROPC.md
@@ -51,7 +51,7 @@ if err != nil {
 }
 
 // Define email message
-message := *gomail.NewEmailMessage("your-email_or_alias@example.com",[]string{"recipient@example.com"}, "Test Email with attachment", "This is the plain text part of the email.").
+message := gomail.NewEmailMessage("your-email_or_alias@example.com",[]string{"recipient@example.com"}, "Test Email with attachment", "This is the plain text part of the email.").
 		SetHTML("<p>This is the <b>HTML</b> part of the <i>email</i>.</p>").AddAttachments(gomail.Attachment{
 			Filename: "attachment.jpg",  Content: attachmentContent,
 		})

--- a/docs/Microsoft365_Credentials_app.md
+++ b/docs/Microsoft365_Credentials_app.md
@@ -51,7 +51,7 @@ if err != nil {
 }
 
 // Define email message
-message := *gomail.NewEmailMessage("your-email_or_alias@example.com",[]string{"recipient@example.com"}, "Test Email with attachment", "This is the plain text part of the email.").
+message := gomail.NewEmailMessage("your-email_or_alias@example.com",[]string{"recipient@example.com"}, "Test Email with attachment", "This is the plain text part of the email.").
 		SetHTML("<p>This is the <b>HTML</b> part of the <i>email</i>.</p>").AddAttachments(gomail.Attachment{
 			Filename: "attachment.jpg",  Content: attachmentContent,
 		})

--- a/docs/Microsoft365_Credentials_credentials.md
+++ b/docs/Microsoft365_Credentials_credentials.md
@@ -50,7 +50,7 @@ if err != nil {
 }
 
 // Define email message
-message := *gomail.NewEmailMessage("your-email_or_alias@example.com",[]string{"recipient@example.com"}, "Test Email with attachment", "This is the plain text part of the email.").
+message := gomail.NewEmailMessage("your-email_or_alias@example.com",[]string{"recipient@example.com"}, "Test Email with attachment", "This is the plain text part of the email.").
 		SetHTML("<p>This is the <b>HTML</b> part of the <i>email</i>.</p>").AddAttachments(gomail.Attachment{
 			Filename: "attachment.jpg",  Content: attachmentContent,
 		})

--- a/docs/Microsoft365_Credentials_managed_id.md
+++ b/docs/Microsoft365_Credentials_managed_id.md
@@ -38,7 +38,7 @@ if err != nil {
 }
 
 // Define email message
-message := *gomail.NewEmailMessage("your-email_or_alias@example.com",[]string{"recipient@example.com"}, "Test Email with attachment", "This is the plain text part of the email.").
+message := gomail.NewEmailMessage("your-email_or_alias@example.com",[]string{"recipient@example.com"}, "Test Email with attachment", "This is the plain text part of the email.").
 		SetHTML("<p>This is the <b>HTML</b> part of the <i>email</i>.</p>").AddAttachments(gomail.Attachment{
 			Filename: "attachment.jpg",  Content: attachmentContent,
 		})

--- a/docs/Microsoft365_Credentials_user.md
+++ b/docs/Microsoft365_Credentials_user.md
@@ -51,7 +51,7 @@ if err != nil {
 }
 
 // Define email message
-message := *gomail.NewEmailMessage("your-email_or_alias@example.com",[]string{"recipient@example.com"}, "Test Email with attachment", "This is the plain text part of the email.").
+message := gomail.NewEmailMessage("your-email_or_alias@example.com",[]string{"recipient@example.com"}, "Test Email with attachment", "This is the plain text part of the email.").
 		SetHTML("<p>This is the <b>HTML</b> part of the <i>email</i>.</p>").AddAttachments(gomail.Attachment{
 			Filename: "attachment.jpg",  Content: attachmentContent,
 		})

--- a/docs/Postmark_Credentials.md
+++ b/docs/Postmark_Credentials.md
@@ -39,7 +39,7 @@ if err != nil {
 }
 
 // Define email message
-message := *gomail.NewEmailMessage("your-email_or_alias@example.com",[]string{"recipient@example.com"}, "Test Email with attachment", "This is the plain text part of the email.").
+message := gomail.NewEmailMessage("your-email_or_alias@example.com",[]string{"recipient@example.com"}, "Test Email with attachment", "This is the plain text part of the email.").
 		SetHTML("<p>This is the <b>HTML</b> part of the <i>email</i>.</p>").AddAttachments(gomail.Attachment{
 			Filename: "attachment.jpg",  Content: attachmentContent,
 		})

--- a/docs/SMTP_Credentials.md
+++ b/docs/SMTP_Credentials.md
@@ -44,7 +44,7 @@ if err != nil {
 }
 
 // Define email message
-message := *gomail.NewEmailMessage("your-email_or_alias@example.com",[]string{"recipient@example.com"}, "Test Email with attachment", "This is the plain text part of the email.").
+message := gomail.NewEmailMessage("your-email_or_alias@example.com",[]string{"recipient@example.com"}, "Test Email with attachment", "This is the plain text part of the email.").
 		SetHTML("<p>This is the <b>HTML</b> part of the <i>email</i>.</p>").AddAttachments(gomail.Attachment{
 			Filename: "attachment.jpg",  Content: attachmentContent,
 		})

--- a/docs/SendGrid_Credentials.md
+++ b/docs/SendGrid_Credentials.md
@@ -36,7 +36,7 @@ if err != nil {
 }
 
 // Define email message
-message := *gomail.NewEmailMessage("your-email_or_alias@example.com",[]string{"recipient@example.com"}, "Test Email with attachment", "This is the plain text part of the email.").
+message := gomail.NewEmailMessage("your-email_or_alias@example.com",[]string{"recipient@example.com"}, "Test Email with attachment", "This is the plain text part of the email.").
 		SetHTML("<p>This is the <b>HTML</b> part of the <i>email</i>.</p>").AddAttachments(gomail.Attachment{
 			Filename: "attachment.jpg",  Content: attachmentContent,
 		})

--- a/email_sender.go
+++ b/email_sender.go
@@ -69,10 +69,10 @@ const DefaultMaxAttachmentSize = 25 * 1024 * 1024 // 25 MB
 type EmailSender interface {
 	// SendEmail sends an email with the given message.
 	// Parameters:
-	// - message: An EmailMessage struct containing the details of the email to be sent.
+	// - message: A pointer to an EmailMessage struct containing the details of the email to be sent.
 	// Returns:
 	// - error: An error if sending the email fails, otherwise nil.
-	SendEmail(message EmailMessage) error
+	SendEmail(message *EmailMessage) error
 }
 
 // EmailMessage contains the fields for sending an email.

--- a/providers/gmail/gmail_email_sender.go
+++ b/providers/gmail/gmail_email_sender.go
@@ -47,7 +47,7 @@ func (ms *gmailMessageSenderWrapper) send(message *gmail.Message) (*gmail.Messag
 //
 // Returns:
 //   - error: An error if sending the email fails.
-func (s *gmailMessageSenderWrapper) SendEmail(message gomail.EmailMessage) error {
+func (s *gmailMessageSenderWrapper) SendEmail(message *gomail.EmailMessage) error {
 	mimeMessage, err := providers.BuildMimeMessage(message)
 	if err != nil {
 		return fmt.Errorf("unable to build MIME message: %w", err)

--- a/providers/gmail/gmail_email_sender_test.go
+++ b/providers/gmail/gmail_email_sender_test.go
@@ -22,6 +22,11 @@ type MockTokenManager struct {
 	err   error
 }
 
+// TestEmailSenderImplementation checks if gmailMessageSenderWrapper implements the EmailSender interface
+func TestEmailSenderImplementation(t *testing.T) {
+	var _ gomail.EmailSender = (*gmailMessageSenderWrapper)(nil)
+}
+
 func (m *MockTokenManager) GetToken() ([]byte, error) {
 	return m.token, m.err
 }
@@ -100,7 +105,7 @@ func (m *mockInvalidTokenManager) GetToken() ([]byte, error) {
 func TestSendEmailWithMockService(t *testing.T) {
 	emailSender := buildMockGmailMessageSenderWrapper(nil)
 
-	message := *gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
+	message := gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
 
 	err := emailSender.SendEmail(message)
 	assert.NoError(t, err)
@@ -108,7 +113,7 @@ func TestSendEmailWithMockService(t *testing.T) {
 
 func TestSendEmailWithSendMessageError(t *testing.T) {
 	emailSender := buildMockGmailMessageSenderWrapper(errors.New("send message error"))
-	message := *gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
+	message := gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
 
 	err := emailSender.SendEmail(message)
 	assert.Error(t, err)
@@ -117,7 +122,7 @@ func TestSendEmailWithSendMessageError(t *testing.T) {
 func TestSendEmailWithMockServiceError(t *testing.T) {
 	emailSender := buildMockGmailMessageSenderWrapper(errors.New("mock service error"))
 
-	message := *gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
+	message := gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
 
 	err := emailSender.SendEmail(message)
 	assert.Error(t, err)
@@ -126,7 +131,7 @@ func TestSendEmailWithMockServiceError(t *testing.T) {
 func TestSendEmailWithBCC(t *testing.T) {
 	emailSender := buildMockGmailMessageSenderWrapper(nil)
 
-	message := *gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.").
+	message := gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.").
 		SetBCC([]string{"bcc@example.com"})
 
 	err := emailSender.SendEmail(message)
@@ -317,7 +322,7 @@ func TestNewGmailEmailSenderJWTAccessInvalidJson(t *testing.T) {
 func TestSendEmailWithNilGmailService(t *testing.T) {
 	emailSender := &gmailMessageSenderWrapper{}
 
-	message := *gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
+	message := gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
 
 	err := emailSender.SendEmail(message)
 	assert.Error(t, err)

--- a/providers/helper_functions.go
+++ b/providers/helper_functions.go
@@ -14,7 +14,7 @@ import (
 // HTML content, and multiple attachments.
 //
 // Parameters:
-// - message: An EmailMessage struct containing the details of the email to be sent.
+// - message: A pointer to an EmailMessage struct containing the details of the email to be sent.
 //
 // Returns:
 // - []byte: A byte slice containing the complete MIME message.
@@ -22,7 +22,7 @@ import (
 //
 // Example:
 //
-//	message := *gomail.NewEmailMessage(
+//	message := gomail.NewEmailMessage(
 //		"sender@example.com",
 //		[]string["recipient@example.com"],
 //		"Test Email",
@@ -36,7 +36,7 @@ import (
 //	    log.Fatalf("Failed to build MIME message: %v", err)
 //	}
 //	fmt.Println(string(mimeMessage))
-func BuildMimeMessage(message gomail.EmailMessage) ([]byte, error) {
+func BuildMimeMessage(message *gomail.EmailMessage) ([]byte, error) {
 	var msg bytes.Buffer
 
 	// Determine boundaries

--- a/providers/helper_functions_test.go
+++ b/providers/helper_functions_test.go
@@ -11,19 +11,19 @@ import (
 
 func TestBuildMimeMessage(t *testing.T) {
 	tests := []struct {
-		message  gomail.EmailMessage
+		message  *gomail.EmailMessage
 		contains []string
 	}{
 		{
-			*gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email."),
+			gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email."),
 			[]string{"From: sender@example.com", "To: recipient@example.com", "Subject: Test Email", "This is a test email."},
 		},
 		{
-			*gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "<p>This is a test email.</p>"),
+			gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "<p>This is a test email.</p>"),
 			[]string{"From: sender@example.com", "To: recipient@example.com", "Subject: Test Email", "Content-Type: text/html", "<p>This is a test email.</p>"},
 		},
 		{
-			*gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.").
+			gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.").
 				SetCC([]string{"cc@example.com"}).
 				SetBCC([]string{"bcc@example.com"}).
 				SetAttachments([]gomail.Attachment{
@@ -32,7 +32,7 @@ func TestBuildMimeMessage(t *testing.T) {
 			[]string{"From: sender@example.com", "To: recipient@example.com", "Cc: cc@example.com", "Subject: Test Email", "This is a test email.", "Content-Disposition: attachment; filename=\"test.txt\"", base64.StdEncoding.EncodeToString([]byte("This is a test attachment."))},
 		},
 		{
-			*gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.").
+			gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.").
 				SetCC([]string{"cc@example.com"}).
 				SetBCC([]string{"bcc@example.com"}).
 				SetReplyTo("reply-to@example.com"),

--- a/providers/mailgun/mailgun_email_sender.go
+++ b/providers/mailgun/mailgun_email_sender.go
@@ -42,11 +42,11 @@ func NewMailgunEmailSender(domain, apiKey string) (*mailgunEmailSender, error) {
 // It constructs the email message from the given EmailMessage and sends it using the Mailgun API.
 //
 // Parameters:
-//   - message: An EmailMessage struct that contains the details of the email to be sent, including the sender, recipients, subject, body content, and any attachments.
+//   - message: A pointer to an EmailMessage struct that contains the details of the email to be sent, including the sender, recipients, subject, body content, and any attachments.
 //
 // Returns:
 //   - error: An error if the email sending fails, otherwise nil.
-func (s *mailgunEmailSender) SendEmail(message gomail.EmailMessage) error {
+func (s *mailgunEmailSender) SendEmail(message *gomail.EmailMessage) error {
 	mg := s.mailgunClient
 
 	mGMessage := mg.NewMessage(

--- a/providers/mailgun/mailgun_email_sender_test.go
+++ b/providers/mailgun/mailgun_email_sender_test.go
@@ -10,6 +10,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestEmailSenderImplementation checks if mailgunEmailSender implements the EmailSender interface
+func TestEmailSenderImplementation(t *testing.T) {
+	var _ gomail.EmailSender = (*mailgunEmailSender)(nil)
+}
+
 // Mock implementations for Mailgun
 type mockMailgun struct{}
 
@@ -45,7 +50,7 @@ func TestMailgunEmailSender_SendEmail(t *testing.T) {
 		mailgunClient: &mockMailgun{},
 	}
 
-	message := *gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.").
+	message := gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.").
 		SetCC([]string{"cc@example.com"}).
 		SetBCC([]string{"bcc@example.com"}).
 		SetReplyTo("replyto@example.com").
@@ -65,7 +70,7 @@ func TestMailgunEmailSender_SendEmailWithSendError(t *testing.T) {
 		mailgunClient: &mockMailgunWithError{},
 	}
 
-	message := *gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
+	message := gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
 
 	err := emailSender.SendEmail(message)
 	assert.Error(t, err)
@@ -77,7 +82,7 @@ func TestMailgunEmailSender_SendEmailWithEmptyFields(t *testing.T) {
 		mailgunClient: &mockMailgun{},
 	}
 
-	message := *gomail.NewEmailMessage(
+	message := gomail.NewEmailMessage(
 		"sender@example.com",
 		[]string{},
 		"",

--- a/providers/mandrill/mandrill_email_sender.go
+++ b/providers/mandrill/mandrill_email_sender.go
@@ -43,11 +43,11 @@ func NewMandrillEmailSender(apiKey string) (*mandrillEmailSender, error) {
 // It constructs the email message from the given EmailMessage and sends it using the Mandrill API.
 //
 // Parameters:
-//   - message: An EmailMessage struct that contains the details of the email to be sent, including the sender, recipients, subject, body content, and any attachments.
+//   - message: A pointer to an EmailMessage struct that contains the details of the email to be sent, including the sender, recipients, subject, body content, and any attachments.
 //
 // Returns:
 //   - error: An error if the email sending fails, otherwise nil.
-func (s *mandrillEmailSender) SendEmail(message gomail.EmailMessage) error {
+func (s *mandrillEmailSender) SendEmail(message *gomail.EmailMessage) error {
 	maMessage := mandrillMessage{
 		FromEmail: message.GetFrom(),
 		To:        make([]mandrillRecipient, 0),

--- a/providers/mandrill/mandrill_email_sender_test.go
+++ b/providers/mandrill/mandrill_email_sender_test.go
@@ -10,6 +10,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestEmailSenderImplementation checks if mandrillEmailSender implements the EmailSender interface
+func TestEmailSenderImplementation(t *testing.T) {
+	var _ gomail.EmailSender = (*mandrillEmailSender)(nil)
+}
+
 func TestNewMandrillEmailSender(t *testing.T) {
 	apiKey := "test-api-key"
 	emailSender, err := NewMandrillEmailSender(apiKey)
@@ -22,7 +27,7 @@ func TestMandrillEmailSender_SendEmail(t *testing.T) {
 	emailSender, err := NewMandrillEmailSender("test-api-key")
 	assert.NoError(t, err)
 
-	message := *gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.").
+	message := gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.").
 		SetCC([]string{"cc@example.com"}).
 		SetBCC([]string{"bcc@example.com"}).
 		SetReplyTo("replyto@example.com").
@@ -50,7 +55,7 @@ func TestMandrillEmailSender_SendEmailWithError(t *testing.T) {
 	emailSender, err := NewMandrillEmailSender("test-api-key")
 	assert.NoError(t, err)
 
-	message := *gomail.NewEmailMessage(
+	message := gomail.NewEmailMessage(
 		string(make([]byte, 1<<20)), // Intentionally large string to cause error
 		[]string{"recipient@example.com"},
 		"Test Email",
@@ -65,7 +70,7 @@ func TestMandrillEmailSender_SendEmailNewRequestError(t *testing.T) {
 	emailSender, err := NewMandrillEmailSender("test-api-key")
 	assert.NoError(t, err)
 
-	message := *gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
+	message := gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
 
 	emailSender.url = "no a url"
 	emailSender.requestMethod = "no a request method"
@@ -79,7 +84,7 @@ func TestMandrillEmailSender_SendEmailWithSendError(t *testing.T) {
 	emailSender, err := NewMandrillEmailSender("test-api-key")
 	assert.NoError(t, err)
 
-	message := *gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
+	message := gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
 
 	// Mock server to simulate a server error
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -98,7 +103,7 @@ func TestMandrillEmailSender_SendEmailWithSendTimeOutError(t *testing.T) {
 	emailSender, err := NewMandrillEmailSender("test-api-key")
 	assert.NoError(t, err)
 
-	message := *gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
+	message := gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
 
 	// Mock server to simulate a server error
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -118,7 +123,7 @@ func TestMandrillEmailSender_SendEmailWithNon200StatusCode(t *testing.T) {
 	emailSender, err := NewMandrillEmailSender("test-api-key")
 	assert.NoError(t, err)
 
-	message := *gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
+	message := gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
 
 	// Mock server to simulate a non-200 status code response
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -137,7 +142,7 @@ func TestMandrillEmailSender_SendEmailWithEmptyFields(t *testing.T) {
 	emailSender, err := NewMandrillEmailSender("test-api-key")
 	assert.NoError(t, err)
 
-	message := *gomail.NewEmailMessage(
+	message := gomail.NewEmailMessage(
 		"sender@example.com",
 		[]string{},
 		"",

--- a/providers/microsoft365/microsoft365_email_sender.go
+++ b/providers/microsoft365/microsoft365_email_sender.go
@@ -22,11 +22,11 @@ type mSGraphEmailSender struct {
 // SendEmail sends an email using the Microsoft Graph API.
 //
 // Parameters:
-//   - message: An EmailMessage struct that contains the details of the email to be sent, including the sender, recipients, subject, body content, and any attachments.
+//   - message: A pointer to an EmailMessage struct that contains the details of the email to be sent, including the sender, recipients, subject, body content, and any attachments.
 //
 // Returns:
 //   - error: An error if the email sending fails, otherwise nil.
-func (s *mSGraphEmailSender) SendEmail(message gomail.EmailMessage) error {
+func (s *mSGraphEmailSender) SendEmail(message *gomail.EmailMessage) error {
 	if s.userRequestBuilder == nil {
 		return fmt.Errorf("error: no user request builder available")
 	}
@@ -47,12 +47,12 @@ func (s *mSGraphEmailSender) SendEmail(message gomail.EmailMessage) error {
 // composeMsMessage creates a new email message based on the provided message.
 //
 // Parameters:
-//   - message: An EmailMessage struct that contains the details of the email to be sent,
+//   - message: A pointer to an EmailMessage struct that contains the details of the email to be sent,
 //     including the sender, recipients, subject, body content, and any attachments.
 //
 // Returns:
 //   - *models.Message: A pointer to the composed Message object ready to be sent via the Microsoft Graph API.
-func composeMsMessage(message gomail.EmailMessage) *models.Message {
+func composeMsMessage(message *gomail.EmailMessage) *models.Message {
 
 	// Create the message
 	body := models.NewItemBody()

--- a/providers/microsoft365/microsoft365_email_sender_test.go
+++ b/providers/microsoft365/microsoft365_email_sender_test.go
@@ -21,6 +21,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestEmailSenderImplementation checks if mSGraphEmailSender implements the EmailSender interface
+func TestEmailSenderImplementation(t *testing.T) {
+	var _ gomail.EmailSender = (*mSGraphEmailSender)(nil)
+}
+
 type MockMSAuthenticationProvider struct {
 }
 
@@ -82,7 +87,7 @@ func TestSendEmail(t *testing.T) {
 		Content:  []byte("test_attachment_content"),
 	}
 
-	message := *gomail.NewEmailMessage(
+	message := gomail.NewEmailMessage(
 		"sender@example.com",
 		[]string{"recipient@example.com"},
 		"Test Subject",
@@ -100,7 +105,7 @@ func TestSendEmail(t *testing.T) {
 }
 
 func TestComposeMessage_PlainTextEmail(t *testing.T) {
-	message := *gomail.NewEmailMessage(
+	message := gomail.NewEmailMessage(
 		"sender@example.com",
 		[]string{"recipient@example.com"},
 		"Test Subject",
@@ -118,7 +123,7 @@ func TestComposeMessage_PlainTextEmail(t *testing.T) {
 }
 
 func TestComposeMessage_HTMLEmail(t *testing.T) {
-	message := *gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Subject", "<p>Test Body</p>")
+	message := gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Subject", "<p>Test Body</p>")
 
 	msMessage := composeMsMessage(message)
 
@@ -129,7 +134,7 @@ func TestComposeMessage_HTMLEmail(t *testing.T) {
 }
 
 func TestComposeMessage_WithCC(t *testing.T) {
-	message := *gomail.NewEmailMessage(
+	message := gomail.NewEmailMessage(
 		"sender@example.com",
 		[]string{"recipient@example.com"},
 		"Test Subject",
@@ -143,7 +148,7 @@ func TestComposeMessage_WithCC(t *testing.T) {
 }
 
 func TestComposeMessage_WithBCC(t *testing.T) {
-	message := *gomail.NewEmailMessage(
+	message := gomail.NewEmailMessage(
 		"sender@example.com",
 		[]string{"recipient@example.com"},
 		"Test Subject",
@@ -157,7 +162,7 @@ func TestComposeMessage_WithBCC(t *testing.T) {
 }
 
 func TestComposeMessage_WithReplyTo(t *testing.T) {
-	message := *gomail.NewEmailMessage(
+	message := gomail.NewEmailMessage(
 		"sender@example.com",
 		[]string{"recipient@example.com"},
 		"Test Subject",
@@ -177,7 +182,7 @@ func TestComposeMessage_WithAttachments(t *testing.T) {
 		Content:  []byte("test_attachment_content"),
 	}
 
-	message := *gomail.NewEmailMessage(
+	message := gomail.NewEmailMessage(
 		"sender@example.com",
 		[]string{"recipient@example.com"},
 		"Test Subject",
@@ -194,7 +199,7 @@ func TestComposeMessage_WithAttachments(t *testing.T) {
 }
 
 func TestComposeMessage_EmptyFields(t *testing.T) {
-	message := *gomail.NewEmailMessage("", []string{}, "", "")
+	message := gomail.NewEmailMessage("", []string{}, "", "")
 	msMessage := composeMsMessage(message)
 
 	assert.NotNil(t, msMessage)
@@ -259,7 +264,7 @@ func TestSendEmail_NoUserRequestBuilder(t *testing.T) {
 		Content:  []byte("test_attachment_content"),
 	}
 
-	message := *gomail.NewEmailMessage(
+	message := gomail.NewEmailMessage(
 		"sender@example.com",
 		[]string{"recipient@example.com"},
 		"Test Subject",
@@ -282,7 +287,7 @@ func TestComposeMessage_LargeAttachment(t *testing.T) {
 		Content:  largeContent,
 	}
 
-	message := *gomail.NewEmailMessage(
+	message := gomail.NewEmailMessage(
 		"sender@example.com",
 		[]string{"recipient@example.com"},
 		"Test Subject",
@@ -306,7 +311,7 @@ func TestComposeMessage_MultipleAttachments(t *testing.T) {
 		Content:  []byte("test_attachment_content2"),
 	}
 
-	message := *gomail.NewEmailMessage(
+	message := gomail.NewEmailMessage(
 		"sender@example.com",
 		[]string{"recipient@example.com"},
 		"Test Subject",
@@ -323,7 +328,7 @@ func TestComposeMessage_MultipleAttachments(t *testing.T) {
 }
 
 func TestComposeMessage_MissingFields(t *testing.T) {
-	message := *gomail.NewEmailMessage(
+	message := gomail.NewEmailMessage(
 		"sender@example.com",
 		[]string{"recipient@example.com"},
 		"", "")
@@ -347,7 +352,7 @@ func TestSendEmail_FailedSend(t *testing.T) {
 		Content:  []byte("test_attachment_content"),
 	}
 
-	message := *gomail.NewEmailMessage(
+	message := gomail.NewEmailMessage(
 		"sender@example.com",
 		[]string{"recipient@example.com"},
 		"Test Subject",

--- a/providers/postmark/postmark_email_sender.go
+++ b/providers/postmark/postmark_email_sender.go
@@ -43,11 +43,11 @@ func NewPostmarkEmailSender(serverToken string) (*postmarkEmailSender, error) {
 // It constructs the email message from the given EmailMessage and sends it using the Postmark API.
 //
 // Parameters:
-//   - message: An EmailMessage struct that contains the details of the email to be sent, including the sender, recipients, subject, body content, and any attachments.
+//   - message: A pointer to an EmailMessage struct that contains the details of the email to be sent, including the sender, recipients, subject, body content, and any attachments.
 //
 // Returns:
 //   - error: An error if the email sending fails, otherwise nil.
-func (s *postmarkEmailSender) SendEmail(message gomail.EmailMessage) error {
+func (s *postmarkEmailSender) SendEmail(message *gomail.EmailMessage) error {
 	emailStruct := struct {
 		From        string               `json:"From"`
 		To          string               `json:"To"`

--- a/providers/postmark/postmark_email_sender_test.go
+++ b/providers/postmark/postmark_email_sender_test.go
@@ -10,6 +10,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestEmailSenderImplementation checks if postmarkEmailSender implements the EmailSender interface
+func TestEmailSenderImplementation(t *testing.T) {
+	var _ gomail.EmailSender = (*postmarkEmailSender)(nil)
+}
+
 func TestNewPostmarkEmailSender(t *testing.T) {
 	serverToken := "test-server-token"
 	emailSender, err := NewPostmarkEmailSender(serverToken)
@@ -23,7 +28,7 @@ func TestNewPostmarkEmailSender(t *testing.T) {
 func TestPostmarkEmailSender_SendEmail(t *testing.T) {
 	emailSender, err := NewPostmarkEmailSender("test-server-token")
 	assert.NoError(t, err)
-	message := *gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.").
+	message := gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.").
 		SetCC([]string{"cc@example.com"}).
 		SetBCC([]string{"bcc@example.com"}).
 		SetReplyTo("replyto@example.com").
@@ -50,7 +55,7 @@ func TestPostmarkEmailSender_SendEmail(t *testing.T) {
 func TestPostmarkEmailSender_SendEmailWithMarshalError(t *testing.T) {
 	emailSender, err := NewPostmarkEmailSender("test-server-token")
 	assert.NoError(t, err)
-	message := *gomail.NewEmailMessage(
+	message := gomail.NewEmailMessage(
 		string(make([]byte, 1<<20)), // Intentionally large string to cause marshal error
 		[]string{"recipient@example.com"},
 		"Test Subject",
@@ -65,7 +70,7 @@ func TestPostmarkEmailSender_SendEmailWithRequestCreationError(t *testing.T) {
 	emailSender, err := NewPostmarkEmailSender("test-server-token")
 	assert.NoError(t, err)
 
-	message := *gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
+	message := gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
 
 	emailSender.url = "no a url"
 	emailSender.requestMethod = "no a request method"
@@ -78,7 +83,7 @@ func TestPostmarkEmailSender_SendEmailWithSendError(t *testing.T) {
 	emailSender, err := NewPostmarkEmailSender("test-server-token")
 	assert.NoError(t, err)
 
-	message := *gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
+	message := gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
 
 	// Mock server to simulate a server error
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -99,7 +104,7 @@ func TestPostmarkEmailSender_SendEmailWithNon200StatusCode(t *testing.T) {
 	emailSender, err := NewPostmarkEmailSender("test-server-token")
 	assert.NoError(t, err)
 
-	message := *gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
+	message := gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
 
 	// Mock server to simulate a non-200 status code response
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -118,7 +123,7 @@ func TestPostmarkEmailSender_SendEmailWithEmptyFields(t *testing.T) {
 	emailSender, err := NewPostmarkEmailSender("test-server-token")
 	assert.NoError(t, err)
 
-	message := *gomail.NewEmailMessage(
+	message := gomail.NewEmailMessage(
 		"sender@example.com",
 		[]string{},
 		"",

--- a/providers/sendgrid/sendgrid_email_sender.go
+++ b/providers/sendgrid/sendgrid_email_sender.go
@@ -33,11 +33,11 @@ func NewSendGridEmailSender(apiKey string) (*sendGridEmailSender, error) {
 // It constructs the email message from the given EmailMessage and sends it using the SendGrid API.
 //
 // Parameters:
-//   - message: An EmailMessage struct that contains the details of the email to be sent, including the sender, recipients, subject, body content, and any attachments.
+//   - message: A pointer to an EmailMessage struct that contains the details of the email to be sent, including the sender, recipients, subject, body content, and any attachments.
 //
 // Returns:
 //   - error: An error if the email sending fails, otherwise nil.
-func (s *sendGridEmailSender) SendEmail(message gomail.EmailMessage) error {
+func (s *sendGridEmailSender) SendEmail(message *gomail.EmailMessage) error {
 	from := mail.NewEmail("", message.GetFrom())
 	toRecipients := []*mail.Email{}
 

--- a/providers/sendgrid/sendgrid_email_sender_test.go
+++ b/providers/sendgrid/sendgrid_email_sender_test.go
@@ -13,6 +13,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestEmailSenderImplementation checks if sendGridEmailSender implements the EmailSender interface
+func TestEmailSenderImplementation(t *testing.T) {
+	var _ gomail.EmailSender = (*sendGridEmailSender)(nil)
+}
+
 // Mocking the SendGrid API response
 func mockSendGridServer(t *testing.T, statusCode int, responseBody string) *httptest.Server {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -55,7 +60,7 @@ func TestSendGridEmailSender_SendEmail(t *testing.T) {
 
 	emailSender := NewMockSendGridEmailSender("test-api-key", ts.URL)
 
-	message := *gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.").
+	message := gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.").
 		SetCC([]string{"cc@example.com"}).
 		SetBCC([]string{"bcc@example.com"}).
 		SetReplyTo("replyto@example.com").
@@ -76,7 +81,7 @@ func TestSendGridEmailSender_SendEmailWithError(t *testing.T) {
 
 	emailSender := NewMockSendGridEmailSender("test-api-key", ts.URL)
 
-	message := *gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
+	message := gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
 
 	err := emailSender.SendEmail(message)
 	assert.Error(t, err)
@@ -89,7 +94,7 @@ func TestSendGridEmailSender_SendEmailWithNon200StatusCode(t *testing.T) {
 
 	emailSender := NewMockSendGridEmailSender("test-api-key", ts.URL)
 
-	message := *gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
+	message := gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
 
 	err := emailSender.SendEmail(message)
 	assert.Error(t, err)
@@ -102,7 +107,7 @@ func TestSendGridEmailSender_SendEmailWithEmptyFields(t *testing.T) {
 
 	emailSender := NewMockSendGridEmailSender("test-api-key", ts.URL)
 
-	message := *gomail.NewEmailMessage(
+	message := gomail.NewEmailMessage(
 		"sender@example.com",
 		[]string{},
 		"",
@@ -122,7 +127,7 @@ func TestSendGridEmailSender_SendEmailWithAttachments(t *testing.T) {
 	attachmentContent := "This is a test attachment."
 	attachmentContentBase64 := base64.StdEncoding.EncodeToString([]byte(attachmentContent))
 
-	message := *gomail.NewEmailMessage(
+	message := gomail.NewEmailMessage(
 		"sender@example.com",
 		[]string{"recipient@example.com"},
 		"Test Subject",

--- a/providers/ses/ses_email_sender.go
+++ b/providers/ses/ses_email_sender.go
@@ -85,11 +85,11 @@ func NewSESEmailSender(region, sender string) (*sESEmailSender, error) {
 // It constructs the email message from the given EmailMessage and sends it using the SES API.
 //
 // Parameters:
-//   - message: An EmailMessage struct that contains the details of the email to be sent, including the sender, recipients, subject, body content, and any attachments.
+//   - message: A pointer to an EmailMessage struct that contains the details of the email to be sent, including the sender, recipients, subject, body content, and any attachments.
 //
 // Returns:
 //   - error: An error if the email sending fails, otherwise nil.
-func (s *sESEmailSender) SendEmail(message gomail.EmailMessage) error {
+func (s *sESEmailSender) SendEmail(message *gomail.EmailMessage) error {
 	input := &ses.SendEmailInput{
 		Source: aws.String(s.sender),
 		Destination: &ses.Destination{

--- a/providers/ses/ses_email_sender_test.go
+++ b/providers/ses/ses_email_sender_test.go
@@ -12,6 +12,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestEmailSenderImplementation checks if sESEmailSender implements the EmailSender interface
+func TestEmailSenderImplementation(t *testing.T) {
+	var _ gomail.EmailSender = (*sESEmailSender)(nil)
+}
+
 // Mock SES client
 type mockSESClient struct {
 	sesiface.SESAPI
@@ -69,7 +74,7 @@ func TestSESEmailSender_SendEmail(t *testing.T) {
 		sender:    "sender@example.com",
 	}
 
-	message := *gomail.NewFullEmailMessage(
+	message := gomail.NewFullEmailMessage(
 		"sender@example.com",
 		[]string{"recipient@example.com"},
 		"Test Email",
@@ -92,7 +97,7 @@ func TestSESEmailSender_SendEmailWithError(t *testing.T) {
 		sender:    "sender@example.com",
 	}
 
-	message := *gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
+	message := gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
 
 	err := emailSender.SendEmail(message)
 	assert.Error(t, err)
@@ -107,7 +112,7 @@ func TestSESEmailSender_SendEmailWithEmptyFields(t *testing.T) {
 		sender:    "sender@example.com",
 	}
 
-	message := *gomail.NewEmailMessage(
+	message := gomail.NewEmailMessage(
 		"sender@example.com",
 		[]string{},
 		"",
@@ -126,7 +131,7 @@ func TestSESEmailSender_SendEmailWithAttachments(t *testing.T) {
 		sender:    "sender@example.com",
 	}
 
-	message := *gomail.NewEmailMessage(
+	message := gomail.NewEmailMessage(
 		"sender@example.com",
 		[]string{"recipient@example.com"},
 		"Test Subject",
@@ -148,7 +153,7 @@ func TestSESEmailSender_SendEmailWithReplyTo(t *testing.T) {
 		sender:    "sender@example.com",
 	}
 
-	message := *gomail.NewEmailMessage(
+	message := gomail.NewEmailMessage(
 		"sender@example.com",
 		[]string{"recipient@example.com"},
 		"Test Subject",

--- a/providers/smtp/smtp_email_sender.go
+++ b/providers/smtp/smtp_email_sender.go
@@ -82,7 +82,7 @@ const (
 )
 
 // SendEmail sends an email using the specified SMTP settings and authentication method.
-func (s *smtpEmailSender) SendEmail(message gomail.EmailMessage) error {
+func (s *smtpEmailSender) SendEmail(message *gomail.EmailMessage) error {
 	// Include CC and BCC recipients in the SMTP envelope
 	sendMailTo := message.GetTo()
 	sendMailTo = append(sendMailTo, message.GetCC()...)

--- a/providers/smtp/smtp_email_sender_test.go
+++ b/providers/smtp/smtp_email_sender_test.go
@@ -14,6 +14,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestEmailSenderImplementation checks if smtpEmailSender implements the EmailSender interface
+func TestEmailSenderImplementation(t *testing.T) {
+	var _ gomail.EmailSender = (*smtpEmailSender)(nil)
+}
+
 // newMockSMTPServer creates a mock SMTP server for testing purposes.
 func newMockSMTPServer(t *testing.T, handler func(conn net.Conn)) *mockSMTPServer {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
@@ -181,7 +186,7 @@ func TestSendEmailPlainAuth(t *testing.T) {
 	emailSender, err := NewSmtpEmailSender(host, portInt, "user", "password", AUTH_PLAIN)
 	assert.NoError(t, err)
 
-	message := *gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
+	message := gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
 
 	err = emailSender.SendEmail(message)
 	assert.NoError(t, err)
@@ -198,7 +203,7 @@ func TestSendEmailCramMD5Auth(t *testing.T) {
 	emailSender, err := NewSmtpEmailSender(host, portInt, "user", "password", AUTH_CRAM_MD5)
 	assert.NoError(t, err)
 
-	message := *gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
+	message := gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
 
 	err = emailSender.SendEmail(message)
 	assert.NoError(t, err)
@@ -215,7 +220,7 @@ func TestSendEmailError(t *testing.T) {
 	emailSender, err := NewSmtpEmailSender(host, portInt, "user", "wrongpassword", AUTH_PLAIN)
 	assert.NoError(t, err)
 
-	message := *gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
+	message := gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
 
 	err = emailSender.SendEmail(message)
 	assert.Error(t, err)
@@ -226,7 +231,7 @@ func TestSendEmailInvalidServer(t *testing.T) {
 	emailSender, err := NewSmtpEmailSender("invalid.server.com", 587, "user", "password", AUTH_PLAIN)
 	assert.NoError(t, err)
 
-	message := *gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
+	message := gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
 
 	err = emailSender.SendEmail(message)
 	assert.Error(t, err)
@@ -236,7 +241,7 @@ func TestSendEmailMissingSettings(t *testing.T) {
 	emailSender, err := NewSmtpEmailSender("", 0, "", "", AUTH_PLAIN)
 	assert.NoError(t, err)
 
-	message := *gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
+	message := gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
 
 	err = emailSender.SendEmail(message)
 	assert.Error(t, err)
@@ -253,7 +258,7 @@ func TestSendEmailImplicitTLS(t *testing.T) {
 	emailSender, err := NewSmtpEmailSenderWithConnMethod(host, portInt, "user", "password", AUTH_PLAIN, CONN_IMPLICIT)
 	assert.NoError(t, err)
 
-	message := *gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
+	message := gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
 
 	err = emailSender.SendEmail(message)
 	assert.NoError(t, err)
@@ -273,7 +278,7 @@ func TestSendEmailExplicitTLS(t *testing.T) {
 	emailSender, err := NewSmtpEmailSenderWithConnMethod(host, portInt, "user", "password", AUTH_PLAIN, CONN_TLS)
 	assert.NoError(t, err)
 
-	message := *gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
+	message := gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
 
 	err = emailSender.SendEmail(message)
 	assert.NoError(t, err)
@@ -290,7 +295,7 @@ func TestSendEmailExplicitErrorTLS(t *testing.T) {
 	emailSender, err := NewSmtpEmailSenderWithConnMethod(host, portInt, "user", "password", AUTH_PLAIN, CONN_TLS)
 	assert.NoError(t, err)
 
-	message := *gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
+	message := gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
 
 	err = emailSender.SendEmail(message)
 	assert.Error(t, err)
@@ -314,7 +319,7 @@ func TestSendTLSEmailConnectionError(t *testing.T) {
 	emailSender, err := NewSmtpEmailSenderWithConnMethod(host, portInt, "user", "password", AUTH_PLAIN, CONN_TLS)
 	assert.NoError(t, err)
 
-	message := *gomail.NewEmailMessage(
+	message := gomail.NewEmailMessage(
 		"sender@example.com",
 		[]string{"nonexistent@example.com"},
 		"This is a test email.",
@@ -359,7 +364,7 @@ func TestSendTLSEmailEHLOError(t *testing.T) {
 	emailSender, err := NewSmtpEmailSenderWithConnMethod(host, portInt, "user", "password", AUTH_PLAIN, CONN_TLS)
 	assert.NoError(t, err)
 
-	message := *gomail.NewEmailMessage(
+	message := gomail.NewEmailMessage(
 		"sender@example.com",
 		[]string{"nonexistent@example.com"},
 		"Test Email",
@@ -411,7 +416,7 @@ func TestSendTLSEmailAUTHError(t *testing.T) {
 	emailSender, err := NewSmtpEmailSenderWithConnMethod(host, portInt, "user", "password", AUTH_PLAIN, CONN_TLS)
 	assert.NoError(t, err)
 
-	message := *gomail.NewEmailMessage(
+	message := gomail.NewEmailMessage(
 		"sender@example.com",
 		[]string{"nonexistent@example.com"},
 		"This is a test email.",
@@ -465,7 +470,7 @@ func TestSendTLSEmailMailError(t *testing.T) {
 	emailSender, err := NewSmtpEmailSenderWithConnMethod(host, portInt, "user", "password", AUTH_PLAIN, CONN_TLS)
 	assert.NoError(t, err)
 
-	message := *gomail.NewEmailMessage(
+	message := gomail.NewEmailMessage(
 		"sender@example.com",
 		[]string{"nonexistent@example.com"},
 		"This is a test email.",
@@ -520,7 +525,7 @@ func TestSendTLSEmailRcptError(t *testing.T) {
 	emailSender, err := NewSmtpEmailSenderWithConnMethod(host, portInt, "user", "password", AUTH_PLAIN, CONN_TLS)
 	assert.NoError(t, err)
 
-	message := *gomail.NewEmailMessage(
+	message := gomail.NewEmailMessage(
 		"sender@example.com",
 		[]string{"nonexistent@example.com"},
 		"This is a test email.",
@@ -578,7 +583,7 @@ func TestSendTLSEmailDataError(t *testing.T) {
 	emailSender, err := NewSmtpEmailSenderWithConnMethod(host, portInt, "user", "password", AUTH_PLAIN, CONN_TLS)
 	assert.NoError(t, err)
 
-	message := *gomail.NewEmailMessage(
+	message := gomail.NewEmailMessage(
 		"sender@example.com",
 		[]string{"nonexistent@example.com"},
 		"This is a test email.",
@@ -637,7 +642,7 @@ func TestSendTLSEmailDataWriteError(t *testing.T) {
 	emailSender, err := NewSmtpEmailSenderWithConnMethod(host, portInt, "user", "password", AUTH_PLAIN, CONN_TLS)
 	assert.NoError(t, err)
 
-	message := *gomail.NewEmailMessage(
+	message := gomail.NewEmailMessage(
 		"sender@example.com",
 		[]string{"nonexistent@example.com"},
 		"This is a test email.",

--- a/providers/sparkpost/sparkpost_email_sender.go
+++ b/providers/sparkpost/sparkpost_email_sender.go
@@ -42,11 +42,11 @@ func NewSparkPostEmailSender(apiKey string) (*sparkPostEmailSender, error) {
 // It constructs the email message from the given EmailMessage and sends it using the SparkPost API.
 //
 // Parameters:
-//   - message: An EmailMessage struct that contains the details of the email to be sent, including the sender, recipients, subject, body content, and any attachments.
+//   - message: A pointer to an EmailMessage struct that contains the details of the email to be sent, including the sender, recipients, subject, body content, and any attachments.
 //
 // Returns:
 //   - error: An error if the email sending fails, otherwise nil.
-func (s *sparkPostEmailSender) SendEmail(message gomail.EmailMessage) error {
+func (s *sparkPostEmailSender) SendEmail(message *gomail.EmailMessage) error {
 	content := sp.Content{
 		From:    message.GetFrom(),
 		Subject: message.GetSubject(),

--- a/providers/sparkpost/sparkpost_email_sender_test.go
+++ b/providers/sparkpost/sparkpost_email_sender_test.go
@@ -12,6 +12,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestEmailSenderImplementation checks if sparkPostEmailSender implements the EmailSender interface
+func TestEmailSenderImplementation(t *testing.T) {
+	var _ gomail.EmailSender = (*sparkPostEmailSender)(nil)
+}
+
 type mockSparkPostClient struct {
 	client *sp.Client
 	server *httptest.Server
@@ -74,7 +79,7 @@ func TestSparkPostEmailSender_SendEmail(t *testing.T) {
 
 	emailSender := &sparkPostEmailSender{client: mockClient.client}
 
-	message := *gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.").
+	message := gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.").
 		SetCC([]string{"cc@example.com"}).
 		SetBCC([]string{"bcc@example.com"}).
 		SetReplyTo("replyto@example.com").
@@ -99,7 +104,7 @@ func TestSparkPostEmailSender_SendEmailWithError(t *testing.T) {
 
 	emailSender := &sparkPostEmailSender{client: mockClient.client}
 
-	message := *gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
+	message := gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.")
 
 	err := emailSender.SendEmail(message)
 	assert.Error(t, err)
@@ -122,7 +127,7 @@ func TestSparkPostEmailSender_SendEmailWithEmptyFields(t *testing.T) {
 
 	emailSender := &sparkPostEmailSender{client: mockClient.client}
 
-	message := *gomail.NewEmailMessage(
+	message := gomail.NewEmailMessage(
 		"sender@example.com",
 		[]string{},
 		"",
@@ -149,7 +154,7 @@ func TestSparkPostEmailSender_SendEmailWithAttachments(t *testing.T) {
 
 	emailSender := &sparkPostEmailSender{client: mockClient.client}
 
-	message := *gomail.NewEmailMessage(
+	message := gomail.NewEmailMessage(
 		"sender@example.com",
 		[]string{"recipient@example.com"},
 		"Test Email",
@@ -179,7 +184,7 @@ func TestSparkPostEmailSender_SendEmailWithReplyTo(t *testing.T) {
 
 	emailSender := &sparkPostEmailSender{client: mockClient.client}
 
-	message := *gomail.NewEmailMessage(
+	message := gomail.NewEmailMessage(
 		"sender@example.com",
 		[]string{"recipient@example.com"},
 		"Test Email",
@@ -206,7 +211,7 @@ func TestSparkPostEmailSender_SendEmailWithCC(t *testing.T) {
 
 	emailSender := &sparkPostEmailSender{client: mockClient.client}
 
-	message := *gomail.NewEmailMessage(
+	message := gomail.NewEmailMessage(
 		"sender@example.com",
 		[]string{"recipient@example.com"},
 		"Test Email",
@@ -234,7 +239,7 @@ func TestSparkPostEmailSender_SendEmailWithBCC(t *testing.T) {
 
 	emailSender := &sparkPostEmailSender{client: mockClient.client}
 
-	message := *gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.").
+	message := gomail.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Test Email", "This is a test email.").
 		SetBCC([]string{"bcc@example.com"})
 
 	err := emailSender.SendEmail(message)


### PR DESCRIPTION
## Feature/Change EmailMessage Parameter to Pointer in EmailSender Interface for Efficiency

### Description
This pull request introduces an enhancement to the `EmailSender` interface by modifying the `SendEmail` method to accept a pointer to `EmailMessage` rather than passing the struct by value. This change improves efficiency by avoiding the unnecessary copying of the `EmailMessage` struct, particularly when dealing with larger messages or attachments.

- **Related Issue**: Closes #12 
- **Type of Change**:
  - New feature (non-breaking change which adds functionality)

### Checklist

Please ensure the following guidelines are met:

- [x] The code follows the style guidelines of this project.
- [x] A self-review has been performed on the code.
- [x] The code is well-documented, and comments have been added where necessary.
- [x] Tests have been added to prove that the fix is effective or that the feature works. All existing tests pass.
- [x] Commit messages follow the convention `type(scope): description`.
- [x] The pull request has no conflicts with the base branch.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional Information

This change refactors the `EmailSender` interface to improve performance by passing a pointer to `EmailMessage` in the `SendEmail` method. Tests have been updated and added to ensure the functionality remains consistent and efficient. The documentation has been updated to reflect this change.
