### PR TITLE
fix(ci): pin FOSSA Action to a specific commit hash

### DIFF
--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -14,6 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
-      - uses: fossas/fossa-action@main # Use a specific version if locking is preferred
+      - uses: fossas/fossa-action@47ef11b1e1e3812e88dae436ccbd2d0cbd1adab0 # v1.3.3
         with:
           api-key: ${{secrets.fossaApiKey}}


### PR DESCRIPTION
## Pin FOSSA Action to a specific commit hash

### Description
This pull request addresses the issue of using the `main` branch for the FOSSA Action in the GitHub Actions workflow. By pinning the FOSSA Action to a specific commit hash, we ensure stability and prevent potential issues from updates in the main branch.

- **Related Issue**: Closes #17 
- **Type of Change**:
  - Bug fix (non-breaking change which fixes an issue)

### Checklist
Please ensure the following guidelines are met:
- [x] The code follows the style guidelines of this project.
- [x] A self-review has been performed on the code.
- [x] The code is well-documented, and comments have been added where necessary.
- [x] Tests have been added to prove that the fix is effective or that the feature works. All existing tests pass.
- [x] Commit messages follow the convention `type(scope): description`.
- [x] The pull request has no conflicts with the base branch.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional Information
Updated the workflow from `uses: fossas/fossa-action@main` to `uses: fossas/fossa-action@<commit-hash>`, replacing `<commit-hash>` with the specific commit hash.