### PR TITLE
fix: replace deprecated ioutil.ReadFile with os.ReadFile

### DIFF
--- a/email_sender.go
+++ b/email_sender.go
@@ -55,8 +55,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"html"
-	"io/ioutil"
 	"mime"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -490,7 +490,7 @@ func NewAttachment(filename string, content []byte) *Attachment {
 //	fmt.Println(attachment.GetFilename()) // Output: document.pdf
 //	fmt.Println(string(attachment.GetContent())) // Output: (file content)
 func NewAttachmentFromFile(filePath string) (*Attachment, error) {
-	content, err := ioutil.ReadFile(filePath)
+	content, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## fix: replace deprecated ioutil.ReadFile with os.ReadFile

### Description

This pull request addresses the issue of deprecated usage of `io/ioutil.ReadFile` by replacing it with `os.ReadFile`. This change ensures that the code is up-to-date with the latest Go standards.

- **Related Issue**: Closes #19 
- **Type of Change**:
  - Bug fix (non-breaking change which fixes an issue)

### Checklist

Please ensure the following guidelines are met:

- [x] The code follows the style guidelines of this project.
- [x] A self-review has been performed on the code.
- [x] The code is well-documented, and comments have been added where necessary.
- [x] Tests have been added to prove that the fix is effective or that the feature works. All existing tests pass.
- [x] Commit messages follow the convention `type(scope): description`.
- [x] The pull request has no conflicts with the base branch.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional Information

Please provide any additional information or context here. If applicable, add screenshots to help explain the changes.

---