### PR TITLE
retract(versions): retract versions prior to v0.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -71,4 +71,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-retract [v0.0.0, v0.5.1] // Retract versions up to v0.5.1 due to migration from GitLab to GitHub. Previous versions will not be maintained.
+retract [v0.0.0, v0.5.9] // Retract versions up to v0.5.x due to migration from GitLab to GitHub. Previous versions will not be maintained.


### PR DESCRIPTION
### Description

Versions prior to v0.6.0 are retracted due to the migration from GitLab to GitHub. Previous versions will not be maintained. This update adds a retract directive to the go.mod file to mark these versions as no longer usable.

### Checklist

Please ensure the following guidelines are met:

- [X] The code follows the style guidelines of this project.
- [X] A self-review has been performed on the code.
- [X] The code is well-documented, and comments have been added where necessary.
- [X] Tests have been added to prove that the fix is effective or that the feature works. All existing tests pass.
- [X] Commit messages follow the convention `type(scope): description`.
- [X] The pull request has no conflicts with the base branch.
- [X] Any dependent changes have been merged and published in downstream modules.
