### PR TITLE
Feature/sanitizer

### DIFF
--- a/common/attachment.go
+++ b/common/attachment.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"os"
 	"strings"
+
+	"github.com/darkrockmountain/gomail/sanitizer"
 )
 
 // Attachment represents an email attachment with its filename and content.
@@ -76,16 +78,16 @@ func (a *Attachment) SetFilename(filename string) {
 }
 
 // GetFilename safely returns the filename of the attachment.
-// It escapes special characters like "<" to become "&lt;"
+// It uses the default text sanitizer to escape special characters and trim whitespace.
 // If the attachment is nil, it returns an empty string.
+//
 // Returns:
-//   - string: The filename as a string.
-//     Returns an "nil_attachment" string if the attachment is nil.
+// - string: The sanitized filename.
 func (a *Attachment) GetFilename() string {
 	if a == nil {
 		return "nil_attachment"
 	}
-	return sanitizeInput(a.filename)
+	return sanitizer.DefaultTextSanitizer().Sanitize(a.filename)
 }
 
 // GetBase64StringContent returns the content of the attachment as a base64-encoded string.

--- a/common/attachment_test.go
+++ b/common/attachment_test.go
@@ -220,18 +220,20 @@ func TestSetContent(t *testing.T) {
 	})
 }
 
-func TestSanitizeInput(t *testing.T) {
-	t.Run("sanitize input with HTML", func(t *testing.T) {
-		input := "<div>Test</div>"
+func TestSanitizeFilename(t *testing.T) {
+
+	attachment := &Attachment{}
+	t.Run("sanitize Filename with HTML", func(t *testing.T) {
+		fileName := "<div>Test</div>"
 		expected := "&lt;div&gt;Test&lt;/div&gt;"
-		result := sanitizeInput(input)
-		assert.Equal(t, expected, result)
+		attachment.SetFilename(fileName)
+		assert.Equal(t, expected, attachment.GetFilename())
 	})
 
-	t.Run("sanitize input with spaces", func(t *testing.T) {
-		input := "  Test  "
+	t.Run("sanitize Filename with spaces", func(t *testing.T) {
+		fileName := "  Test  "
 		expected := "Test"
-		result := sanitizeInput(input)
-		assert.Equal(t, expected, result)
+		attachment.SetFilename(fileName)
+		assert.Equal(t, expected, attachment.GetFilename())
 	})
 }

--- a/common/utils.go
+++ b/common/utils.go
@@ -1,24 +1,11 @@
 package common
 
 import (
-	"html"
 	"mime"
 	"path/filepath"
 	"regexp"
 	"strings"
-
-	"github.com/microcosm-cc/bluemonday"
 )
-
-// sanitizeInput sanitizes a string to prevent HTML and script injection.
-func sanitizeInput(input string) string {
-	return html.EscapeString(strings.TrimSpace(input))
-}
-
-// sanitizeHtmlInput sanitizes a string to prevent HTML and script injection but conserving the safe html tags.
-func sanitizeHtmlInput(input string) string {
-	return bluemonday.UGCPolicy().Sanitize(input)
-}
 
 // IsHTML checks if a string contains HTML tags.
 // Parameters:

--- a/common/utils_test.go
+++ b/common/utils_test.go
@@ -6,60 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestEmailHTMLBodySanitzers(t *testing.T) {
-
-	html1 := `<div><a href="javascript:alert('XSS1')" onmouseover="alert('XSS2')">XSS<a></div>`
-
-	t.Run("remove potential XSS attack", func(t *testing.T) {
-		expected := `<div>XSS</div>`
-		result := sanitizeHtmlInput(html1)
-		assert.Equal(t, expected, result)
-	})
-
-	html2 := `<a onblur="alert(secret)" href="http://www.google.com">Google</a>`
-
-	t.Run("on methods not allowed", func(t *testing.T) {
-		expected := `<a href="http://www.google.com" rel="nofollow">Google</a>`
-		result := sanitizeHtmlInput(html2)
-		assert.Equal(t, expected, result)
-	})
-
-	html3 := `<p href="http://www.google.com">Google</p>`
-
-	t.Run("<p> can't have href", func(t *testing.T) {
-		expected := `<p>Google</p>`
-		result := sanitizeHtmlInput(html3)
-		assert.Equal(t, expected, result)
-	})
-
-}
-
-func TestEmailHTMLBodySanitizers(t *testing.T) {
-	html1 := `<div><a href="javascript:alert('XSS1')" onmouseover="alert('XSS2')">XSS<a></div>`
-
-	t.Run("remove potential XSS attack", func(t *testing.T) {
-		expected := `<div>XSS</div>`
-		result := sanitizeHtmlInput(html1)
-		assert.Equal(t, expected, result)
-	})
-
-	html2 := `<a onblur="alert(secret)" href="http://www.google.com">Google</a>`
-
-	t.Run("on methods not allowed", func(t *testing.T) {
-		expected := `<a href="http://www.google.com" rel="nofollow">Google</a>`
-		result := sanitizeHtmlInput(html2)
-		assert.Equal(t, expected, result)
-	})
-
-	html3 := `<p href="http://www.google.com">Google</p>`
-
-	t.Run("<p> can't have href", func(t *testing.T) {
-		expected := `<p>Google</p>`
-		result := sanitizeHtmlInput(html3)
-		assert.Equal(t, expected, result)
-	})
-}
-
 func TestStrPtr(t *testing.T) {
 
 	str := "String to test for pointer"

--- a/sanitizer/default_html_sanitizer.go
+++ b/sanitizer/default_html_sanitizer.go
@@ -1,0 +1,30 @@
+package sanitizer
+
+import "github.com/microcosm-cc/bluemonday"
+
+// defaultHtmlSanitizer provides a basic implementation of the Sanitizer interface for HTML content.
+// It uses the bluemonday library to sanitize HTML content, ensuring that only user-generated content
+// (UGC) is allowed. This helps prevent injection attacks by removing potentially dangerous tags and attributes.
+type defaultHtmlSanitizer struct{}
+
+// Sanitize sanitizes HTML content by removing potentially dangerous tags and attributes.
+// It uses the bluemonday UGCPolicy to allow only safe HTML for user-generated content.
+//
+// Parameters:
+// - htmlContent: The HTML content to be sanitized.
+//
+// Returns:
+// - string: The sanitized HTML content.
+func (s *defaultHtmlSanitizer) Sanitize(htmlContent string) string {
+	// Use bluemonday's UGCPolicy for robust HTML sanitization.
+	return bluemonday.UGCPolicy().Sanitize(htmlContent)
+}
+
+// defaultHtmlSanitizerInstance is the singleton instance of defaultHtmlSanitizer.
+var defaultHtmlSanitizerInstance = &defaultHtmlSanitizer{}
+
+// DefaultHtmlSanitizer returns the singleton instance of defaultHtmlSanitizer.
+// This ensures that the instance cannot be modified from outside the package.
+func DefaultHtmlSanitizer() Sanitizer {
+	return defaultHtmlSanitizerInstance
+}

--- a/sanitizer/default_html_sanitizer_test.go
+++ b/sanitizer/default_html_sanitizer_test.go
@@ -1,0 +1,46 @@
+package sanitizer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultHtmlSanitizer(t *testing.T) {
+	sanitizer := DefaultHtmlSanitizer()
+
+	t.Run("remove potential XSS attack", func(t *testing.T) {
+		input := `<div><a href="javascript:alert('XSS1')" onmouseover="alert('XSS2')">XSS<a></div>`
+		expected := `<div>XSS</div>`
+		result := sanitizer.Sanitize(input)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("on methods not allowed", func(t *testing.T) {
+		input := `<a onblur="alert(secret)" href="http://www.google.com">Google</a>`
+		expected := `<a href="http://www.google.com" rel="nofollow">Google</a>`
+		result := sanitizer.Sanitize(input)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("<p> can't have href", func(t *testing.T) {
+		input := `<p href="http://www.google.com">Google</p>`
+		expected := `<p>Google</p>`
+		result := sanitizer.Sanitize(input)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("allow safe HTML tags", func(t *testing.T) {
+		input := `<b>Bold</b> <i>Italic</i> <u>Underline</u>`
+		expected := `<b>Bold</b> <i>Italic</i> <u>Underline</u>`
+		result := sanitizer.Sanitize(input)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("sanitize mixed content", func(t *testing.T) {
+		input := `<div>Hello <script>alert("xss")</script> World</div>`
+		expected := `<div>Hello  World</div>`
+		result := sanitizer.Sanitize(input)
+		assert.Equal(t, expected, result)
+	})
+}

--- a/sanitizer/default_text_sanitizer.go
+++ b/sanitizer/default_text_sanitizer.go
@@ -1,0 +1,30 @@
+package sanitizer
+
+import (
+	"html"
+	"strings"
+)
+
+// defaultTextSanitizer provides a basic implementation of the Sanitizer interface for plain text content.
+type defaultTextSanitizer struct{}
+
+// Sanitize sanitizes plain text content by escaping special characters and trimming whitespace.
+// This method complies with the Sanitizer interface.
+//
+// Parameters:
+// - text: The plain text content to be sanitized.
+//
+// Returns:
+// - string: The sanitized text content.
+func (s *defaultTextSanitizer) Sanitize(text string) string {
+	return html.EscapeString(strings.TrimSpace(text))
+}
+
+// defaultTextSanitizerInstance is the singleton instance of defaultTextSanitizer.
+var defaultTextSanitizerInstance = &defaultTextSanitizer{}
+
+// DefaultTextSanitizer returns the singleton instance of defaultTextSanitizer.
+// This ensures that the instance cannot be modified from outside the package.
+func DefaultTextSanitizer() Sanitizer {
+	return defaultTextSanitizerInstance
+}

--- a/sanitizer/default_text_sanitizer_test.go
+++ b/sanitizer/default_text_sanitizer_test.go
@@ -1,0 +1,39 @@
+package sanitizer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultTextSanitizer(t *testing.T) {
+	sanitizer := DefaultTextSanitizer()
+
+	t.Run("escape special characters", func(t *testing.T) {
+		input := `Hello <world> & "everyone"`
+		expected := `Hello &lt;world&gt; &amp; &#34;everyone&#34;`
+		result := sanitizer.Sanitize(input)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("empty string", func(t *testing.T) {
+		input := ""
+		expected := ""
+		result := sanitizer.Sanitize(input)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("string with spaces", func(t *testing.T) {
+		input := "   "
+		expected := ""
+		result := sanitizer.Sanitize(input)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("string with no special characters", func(t *testing.T) {
+		input := "plain text"
+		expected := "plain text"
+		result := sanitizer.Sanitize(input)
+		assert.Equal(t, expected, result)
+	})
+}

--- a/sanitizer/non_sanitizer.go
+++ b/sanitizer/non_sanitizer.go
@@ -1,0 +1,36 @@
+package sanitizer
+
+// nonSanitizer is an implementation of the Sanitizer interface that performs no sanitization.
+// It returns the input text unchanged. This can be useful in scenarios where no sanitization is desired.
+//
+// WARNING: Using nonSanitizer means that the input content will not be sanitized at all.
+// Ensure that this is acceptable for your use case, as it may introduce security risks, such as
+// injection attacks, if user input is not properly handled.
+//
+// Example usage:
+//
+//	ns := sanitizer.NonSanitizer()
+//	unsanitized := ns.Sanitize("<script>alert('xss')</script>")
+//	// unsanitized will be "<script>alert('xss')</script>"
+type nonSanitizer struct{}
+
+// Sanitize returns the input text without any modifications.
+// This method complies with the Sanitizer interface.
+//
+// Parameters:
+// - text: The content to be "sanitized".
+//
+// Returns:
+// - string: The input text, unchanged.
+func (s *nonSanitizer) Sanitize(text string) string {
+	return text
+}
+
+// nonSanitizerInstance is the singleton instance of nonSanitizer.
+var nonSanitizerInstance = &nonSanitizer{}
+
+// NonSanitizer returns the singleton instance of nonSanitizer.
+// This ensures that the instance cannot be modified from outside the package.
+func NonSanitizer() Sanitizer {
+	return nonSanitizerInstance
+}

--- a/sanitizer/non_sanitizer_test.go
+++ b/sanitizer/non_sanitizer_test.go
@@ -1,0 +1,32 @@
+package sanitizer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNonSanitizer(t *testing.T) {
+	sanitizer := NonSanitizer()
+
+	t.Run("return input as is", func(t *testing.T) {
+		input := `<div><a href="javascript:alert('XSS1')" onmouseover="alert('XSS2')">XSS<a></div>`
+		expected := input
+		result := sanitizer.Sanitize(input)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("empty string", func(t *testing.T) {
+		input := ""
+		expected := ""
+		result := sanitizer.Sanitize(input)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("plain text", func(t *testing.T) {
+		input := "plain text"
+		expected := "plain text"
+		result := sanitizer.Sanitize(input)
+		assert.Equal(t, expected, result)
+	})
+}

--- a/sanitizer/sanitizer.go
+++ b/sanitizer/sanitizer.go
@@ -1,0 +1,40 @@
+// Package sanitizer provides interfaces and default implementations for sanitizing email content.
+//
+// # Overview
+//
+// The sanitizer package defines an interface for content sanitization and provides default implementations
+// for sanitizing plain text and HTML content. This allows for flexible and customizable content sanitization
+// in the gomail project.
+//
+// # Usage
+//
+// To use the sanitizer package, you can either use the provided default implementations or create your
+// own custom implementations of the Sanitizer interface and set them in the EmailMessage struct.
+//
+// Example:
+//
+//	import (
+//	    "github.com/darkrockmountain/gomail/sanitizer"
+//	    "github.com/darkrockmountain/gomail/common"
+//	)
+//
+//	func main() {
+//	    email := common.NewEmailMessage("sender@example.com", []string{"recipient@example.com"}, "Subject", "<p>HTML content</p>")
+//	    customSanitizer := &sanitizer.CustomSanitizer{}
+//	    email.SetCustomTextSanitizer(customSanitizer)
+//	    email.SetCustomHtmlSanitizer(customSanitizer)
+//	}
+//
+// The sanitizer package is designed to be used in conjunction with the gomail project for flexible email content sanitization.
+package sanitizer
+
+// Sanitizer defines a method for sanitizing content.
+// Implement this interface to provide custom sanitization logic for email content.
+type Sanitizer interface {
+	// Sanitize sanitizes the provided content.
+	// Parameters:
+	// - content: The content to be sanitized.
+	// Returns:
+	// - string: The sanitized content.
+	Sanitize(content string) string
+}


### PR DESCRIPTION
### Description
This pull request introduces custom sanitizers for text and HTML content within the `EmailMessage` struct. Users can now specify their own sanitization logic or utilize the default sanitizers provided. This enhancement improves flexibility and security in email content handling. The changes also include comprehensive tests to ensure robust functionality and edge case coverage.

- **Related Issue**: Closes #32 
- **Type of Change**:
  - New feature (non-breaking change which adds functionality)
  - This change requires a documentation update

### Checklist

- [x] The code follows the style guidelines of this project.
- [x] A self-review has been performed on the code.
- [x] The code is well-documented, and comments have been added where necessary.
- [x] Tests have been added to prove that the fix is effective or that the feature works. All existing tests pass.
- [x] Commit messages follow the convention `type(scope): description`.
- [x] The pull request has no conflicts with the base branch.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional Information
This update includes:
- Custom sanitizer methods: `SetCustomTextSanitizer` and `SetCustomHtmlSanitizer`.
- Enhanced tests covering new functionalities and edge cases.
- Updated documentation to reflect the new sanitization capabilities.