### PR TITLE
fix(microsoft365): correct attachment encoding to use raw content

### DIFF
--- a/providers/microsoft365/microsoft365_email_sender.go
+++ b/providers/microsoft365/microsoft365_email_sender.go
@@ -139,7 +139,7 @@ func composeMsMessage(message *gomail.EmailMessage) *models.Message {
 		for i, attachment := range attachments {
 			fileAttachment := models.NewFileAttachment()
 			fileAttachment.SetName(common.StrPtr(attachment.GetFilename()))
-			fileAttachment.SetContentBytes([]byte(attachment.GetBase64StringContent()))
+			fileAttachment.SetContentBytes(attachment.GetRawContent())
 			msAttachments[i] = fileAttachment
 		}
 		msMessage.SetAttachments(msAttachments)

--- a/providers/microsoft365/microsoft365_email_sender_test.go
+++ b/providers/microsoft365/microsoft365_email_sender_test.go
@@ -3,7 +3,6 @@ package microsoft365
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"fmt"
 	"net/http"
 	"testing"
@@ -185,7 +184,7 @@ func TestComposeMessage_WithAttachments(t *testing.T) {
 
 	msMessage := composeMsMessage(message)
 
-	attachmentBase64 := []byte(base64.StdEncoding.EncodeToString([]byte("test_attachment_content")))
+	attachmentBase64 := []byte("test_attachment_content")
 
 	assert.NotNil(t, msMessage)
 	assert.Equal(t, "test.txt", *msMessage.GetAttachments()[0].(*models.FileAttachment).GetName())
@@ -286,7 +285,7 @@ func TestComposeMessage_LargeAttachment(t *testing.T) {
 
 	assert.NotNil(t, msMessage)
 	assert.Equal(t, "large.txt", *msMessage.GetAttachments()[0].(*models.FileAttachment).GetName())
-	assert.True(t, bytes.Equal(attachment.GetBase64Content(), msMessage.GetAttachments()[0].(*models.FileAttachment).GetContentBytes()), "Attachment do not match")
+	assert.True(t, bytes.Equal(attachment.GetRawContent(), msMessage.GetAttachments()[0].(*models.FileAttachment).GetContentBytes()), "Attachment do not match")
 }
 
 func TestComposeMessage_MultipleAttachments(t *testing.T) {
@@ -304,9 +303,9 @@ func TestComposeMessage_MultipleAttachments(t *testing.T) {
 
 	assert.NotNil(t, msMessage)
 	assert.Equal(t, "test1.txt", *msMessage.GetAttachments()[0].(*models.FileAttachment).GetName())
-	assert.Equal(t, attachment1.GetBase64Content(), msMessage.GetAttachments()[0].(*models.FileAttachment).GetContentBytes())
+	assert.Equal(t, attachment1.GetRawContent(), msMessage.GetAttachments()[0].(*models.FileAttachment).GetContentBytes())
 	assert.Equal(t, "test2.txt", *msMessage.GetAttachments()[1].(*models.FileAttachment).GetName())
-	assert.Equal(t, attachment2.GetBase64Content(), msMessage.GetAttachments()[1].(*models.FileAttachment).GetContentBytes())
+	assert.Equal(t, attachment2.GetRawContent(), msMessage.GetAttachments()[1].(*models.FileAttachment).GetContentBytes())
 }
 
 func TestComposeMessage_MissingFields(t *testing.T) {


### PR DESCRIPTION
### Description

This pull request addresses the issue where attachments in emails sent using the Microsoft 365 provider were improperly processed. The attachments were being encoded into Base64 strings and then converted into byte arrays, resulting in incorrect attachment data being sent. The fix ensures that attachments are sent using raw byte data, preserving their integrity.

- **Related Issue**: Closes #45 
- **Type of Change**:
  - Bug fix (non-breaking change which fixes an issue)

### Checklist

Please ensure the following guidelines are met:

- [x] The code follows the style guidelines of this project.
- [x] A self-review has been performed on the code.
- [x] The code is well-documented, and comments have been added where necessary.
- [x] Tests have been added to prove that the fix is effective or that the feature works. All existing tests pass.
- [x] Commit messages follow the convention `type(scope): description`.
- [x] The pull request has no conflicts with the base branch.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional Information

No additional dependencies are required for this change. The fix involves modifying the `composeMsMessage` function in the `microsoft365_email_sender.go` file to use `attachment.GetRawContent()` for setting attachment content bytes.
